### PR TITLE
Add slot removal links.

### DIFF
--- a/seantis/reservation/locales/de/LC_MESSAGES/seantis.reservation.po
+++ b/seantis/reservation/locales/de/LC_MESSAGES/seantis.reservation.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-10-28 16:18+0000\n"
+"POT-Creation-Date: 2013-11-12 12:46+0000\n"
 "PO-Revision-Date: 2012-09-06 11:33+0100\n"
 "Last-Translator: Fabian Reinhard <fabian.reinhard@seantis.ch>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,23 +22,23 @@ msgstr ""
 msgid "${days} days ago, at ${time}"
 msgstr ""
 
-#: ./interfaces.py:614
+#: ./interfaces.py:630
 msgid "%(reason)s - reason for revocation<br>"
 msgstr "%(reason)s - Grund für die Absage<br>"
 
-#: ./utils.py:748
+#: ./utils.py:749
 msgid "%i People Waiting"
 msgstr "%i Personen warten"
 
-#: ./utils.py:729
+#: ./utils.py:730
 msgid "%i%% Free"
 msgstr "%i%% Frei"
 
-#: ./utils.py:736
+#: ./utils.py:737
 msgid "%i/%i Spot Available"
 msgstr "%i/%i Platz Verfügbar"
 
-#: ./utils.py:732
+#: ./utils.py:733
 msgid "%i/%i Spots Available"
 msgstr "%i/%i Plätze Verfügbar"
 
@@ -46,15 +46,15 @@ msgstr "%i/%i Plätze Verfügbar"
 msgid "&lt;&lt; Previous Month"
 msgstr "&lt;&lt; Vorheriger Monat"
 
-#: ./templates/macros.pt:175
+#: ./templates/macros.pt:177
 msgid "&raquo; Edit Formdata"
 msgstr "&raquo; Formdaten Bearbeiten"
 
-#: ./utils.py:587
+#: ./utils.py:588
 msgid "<b>${quota}</b> reservations"
 msgstr "<b>${quota}</b> Reservationen"
 
-#: ./utils.py:589
+#: ./utils.py:590
 msgid "<b>1</b> reservation"
 msgstr "<b>1</b> Reservation"
 
@@ -66,7 +66,7 @@ msgstr "Es existiert bereits eine Einteilung für den gewählten Zeitraum"
 msgid "A pending reservation would be affected by the requested change"
 msgstr "Ein offene Reservierung wäre durch die Änderung betroffen"
 
-#: ./mail.py:495
+#: ./mail.py:530
 msgid "Add email template"
 msgstr "Email Vorlage hinzufügen"
 
@@ -90,35 +90,35 @@ msgstr "Einteilen"
 msgid "Allocation"
 msgstr "Einteilung"
 
-#: ./interfaces.py:785
+#: ./interfaces.py:801
 msgid "Allocation Id"
 msgstr "Allokations ID"
 
-#: ./allocate.py:132
+#: ./allocate.py:133
 msgid "Allocation added"
 msgstr "Einteilung hinzugefügt"
 
-#: ./allocate.py:294
+#: ./allocate.py:295
 msgid "Allocation removed"
 msgstr "Einteilung entfernt"
 
-#: ./allocate.py:251
+#: ./allocate.py:252
 msgid "Allocation saved"
 msgstr "Einteilung gespeichert"
 
-#: ./interfaces.py:520
+#: ./interfaces.py:533
 msgid "Allocations may end every 5 minutes if the allocation is not partly available. If it is partly available the start time may be every x minute where x equals the given raster. The minimum length of an allocation is also either 5 minutes or whatever the value of the raster is."
 msgstr "Einteilungen können alle 5 Minuten enden. Ist die Einstellung 'teilweise verfügbar' gewählt, so kann die Einteilung alle x Minuten enden, wobei x dem Wert des Rasters entspricht."
 
-#: ./interfaces.py:511
+#: ./interfaces.py:524
 msgid "Allocations may start every 5 minutes if the allocation is not partly available. If it is partly available the start time may be every x minute where x equals the given raster."
 msgstr "Einteilungen können alle 5 Minuten beginnen. Ist die Einstellung 'teilweise verfügbar' gewählt, so kann die Einteilung alle x Minuten beginnen, wobei x dem Wert des Rasters entspricht."
 
-#: ./interfaces.py:79
+#: ./interfaces.py:81
 msgid "Always show a specific date"
 msgstr "Immer ein bestimmtes Datum anzeigen"
 
-#: ./interfaces.py:78
+#: ./interfaces.py:80
 msgid "Always show the current date"
 msgstr "Immer das aktuelle Datum anzeigen"
 
@@ -131,12 +131,12 @@ msgid "Approval Email Notifications for Managers"
 msgstr "E-Mail Benachrichtigung für Manager bei Reservationen, die bestätigt werden müssen"
 
 #: ./reports/monthly_report.py:226
-#: ./reserve.py:734
-#: ./templates/macros.pt:134
+#: ./reserve.py:735
+#: ./templates/macros.pt:136
 msgid "Approve"
 msgstr "Zulassen"
 
-#: ./reserve.py:725
+#: ./reserve.py:726
 msgid "Approve reservation"
 msgstr "Reservation zulassen"
 
@@ -145,7 +145,7 @@ msgstr "Reservation zulassen"
 msgid "Approved"
 msgstr "Zugelassen"
 
-#: ./interfaces.py:385
+#: ./interfaces.py:387
 msgid "Available Views"
 msgstr "Verfügbare Ansichten"
 
@@ -153,7 +153,7 @@ msgstr "Verfügbare Ansichten"
 msgid "CSV Format"
 msgstr ""
 
-#: ./interfaces.py:409
+#: ./interfaces.py:411
 msgid "Calendar date shown when opening the calendar."
 msgstr "Das Datum das beim Öffnen des Kalenders angezeigt wird."
 
@@ -161,8 +161,8 @@ msgstr "Das Datum das beim Öffnen des Kalenders angezeigt wird."
 msgid "Can't block period because a reservation already exists."
 msgstr "Die Zeitspanne kann nicht blockiert werden weil schon eine Reservation existiert"
 
-#: ./allocate.py:151
-#: ./reserve.py:538
+#: ./allocate.py:152
+#: ./reserve.py:539
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -178,7 +178,7 @@ msgstr "Zur Reservation / Anmeldung"
 msgid "Compare Resources"
 msgstr "Ressourcen vergleichen"
 
-#: ./templates/macros.pt:191
+#: ./templates/macros.pt:193
 msgid "Concerned Dates"
 msgstr "Betroffene Daten"
 
@@ -190,15 +190,15 @@ msgstr "Reservationen abschliessen"
 msgid "Created"
 msgstr ""
 
-#: ./interfaces.py:341
+#: ./interfaces.py:343
 msgid "DEPRECATED: Approve reservation requests"
 msgstr "DEPRECATED: Approve reservation requests"
 
-#: ./interfaces.py:61
+#: ./interfaces.py:63
 msgid "Daily"
 msgstr "Täglich"
 
-#: ./interfaces.py:69
+#: ./interfaces.py:71
 msgid "Daily View"
 msgstr "Tagesansicht"
 
@@ -206,39 +206,39 @@ msgstr "Tagesansicht"
 msgid "Date"
 msgstr "Datum"
 
-#: ./interfaces.py:544
+#: ./interfaces.py:557
 msgid "Day"
 msgstr "Tag"
 
-#: ./interfaces.py:548
+#: ./interfaces.py:561
 msgid "Days"
 msgstr "Tage"
 
-#: ./interfaces.py:424
+#: ./interfaces.py:426
 msgid "Default Allocation Values"
 msgstr "Standard Einteilungswerte"
 
-#: ./interfaces.py:317
+#: ./interfaces.py:319
 msgid "Defines the minimum length of any given reservation as well as the alignment of the start / end of the allocation. E.g. a raster of 30 minutes means that the allocation can only start at xx:00 and xx:30 respectively"
 msgstr "Definiert die Mindestlänge der Reservationen für diese Einteilung, sowie die automatische Anpassung der Start- bzw. Endzeit. Ein Raster von 30 Minuten bedeuted beispielsweise, dass die Einteilung nur um xx:00 Uhr und xx:30 Uhr beginnen kann."
 
-#: ./allocate.py:278
-#: ./mail.py:504
+#: ./allocate.py:279
+#: ./mail.py:539
 #: ./reports/monthly_report.py:220
 msgid "Delete"
 msgstr "Löschen"
 
 #: ./reports/monthly_report.py:232
-#: ./reserve.py:767
-#: ./templates/macros.pt:130
+#: ./reserve.py:768
+#: ./templates/macros.pt:132
 msgid "Deny"
 msgstr "Ablehnen"
 
-#: ./reserve.py:758
+#: ./reserve.py:759
 msgid "Deny reservation"
 msgstr "Reservation ablehnen"
 
-#: ./interfaces.py:355
+#: ./interfaces.py:357
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -246,11 +246,11 @@ msgstr "Beschreibung"
 msgid "Details"
 msgstr "Details"
 
-#: ./reserve.py:732
+#: ./reserve.py:733
 msgid "Do you really want to approve the following reservations?"
 msgstr "Möchten Sie die folgende Reservation wirklich zulassen?"
 
-#: ./reserve.py:765
+#: ./reserve.py:766
 msgid "Do you really want to deny the following reservations?"
 msgstr "Möchten Sie die folgende Reservation wirklich ablehnen?"
 
@@ -258,11 +258,11 @@ msgstr "Möchten Sie die folgende Reservation wirklich ablehnen?"
 msgid "Do you really want to remove the following allocations?"
 msgstr "Möchten Sie die folgenden Einteilungen wirklich löschen?"
 
-#: ./reserve.py:841
+#: ./reserve.py:842
 msgid "Do you really want to remove the following reservations?"
 msgstr "Wollen sie wirklich die folgenden Reservationen löschen?"
 
-#: ./reserve.py:913
+#: ./reserve.py:912
 msgid "Do you really want to revoke the following reservations?"
 msgstr "Möchten Sie die folgende Reservation wirklich absagen?"
 
@@ -270,22 +270,22 @@ msgstr "Möchten Sie die folgende Reservation wirklich absagen?"
 msgid "Do you want to reserve the following allocations?"
 msgstr "Möchten Sie die folgenden Einteilungen reservieren?"
 
-#: ./allocate.py:223
-#: ./mail.py:503
+#: ./allocate.py:224
+#: ./mail.py:538
 #: ./resource.py:369
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ./reserve.py:1025
-msgid "Edit Formdata"
-msgstr "Formdaten Bearbeiten"
-
-#: ./allocate.py:173
+#: ./allocate.py:174
 msgid "Edit allocation"
 msgstr "Einteilung bearbeiten"
 
+#: ./reserve.py:1029
+msgid "Edit reservation"
+msgstr ""
+
 #: ./exports/reservations.py:45
-#: ./interfaces.py:145
+#: ./interfaces.py:147
 msgid "Email"
 msgstr "Email"
 
@@ -297,31 +297,31 @@ msgstr "Email Benachrichtigung für Manager"
 msgid "Email Notifications for Reservees"
 msgstr "Email Benachrichtigung für Reservierende"
 
-#: ./interfaces.py:677
+#: ./interfaces.py:693
 msgid "Email Subject for Approved Reservations"
 msgstr "Email Betreff für Zugelassene Reservationen"
 
-#: ./interfaces.py:690
+#: ./interfaces.py:706
 msgid "Email Subject for Denied Reservations"
 msgstr "Email Betreff für Abgelehnte Reservationen"
 
-#: ./interfaces.py:662
+#: ./interfaces.py:678
 msgid "Email Subject for Received Reservations"
 msgstr "Email Betreff für Erhaltene Reservationen"
 
-#: ./interfaces.py:633
+#: ./interfaces.py:649
 msgid "Email Subject for Reservation Autoapproved"
 msgstr "Email Betreff für Automatisch Angenommene Reservationen"
 
-#: ./interfaces.py:647
+#: ./interfaces.py:663
 msgid "Email Subject for Reservation Pending"
 msgstr "Email Betreff für Reservationen in der Warteliste"
 
-#: ./interfaces.py:703
+#: ./interfaces.py:719
 msgid "Email Subject for Revoked Reservations"
 msgstr "Email Betreff für Abgesagte Reservationen"
 
-#: ./mail.py:96
+#: ./mail.py:115
 #: ./profiles/default/types/seantis.reservation.emailtemplate.xml
 msgid "Email Template"
 msgstr "Email Vorlage"
@@ -330,36 +330,36 @@ msgstr "Email Vorlage"
 msgid "Email Templates"
 msgstr "Email Vorlagen"
 
-#: ./interfaces.py:684
+#: ./interfaces.py:700
 msgid "Email Text for Approved Reservations"
 msgstr "Email Text für Zugelassene Reservationen"
 
-#: ./interfaces.py:697
+#: ./interfaces.py:713
 msgid "Email Text for Denied Reservations"
 msgstr "Email Text für Abgelehnte Reservationen"
 
-#: ./interfaces.py:671
+#: ./interfaces.py:687
 msgid "Email Text for Received Reservations"
 msgstr "Email Text für Erhaltene Reservationen"
 
-#: ./interfaces.py:641
+#: ./interfaces.py:657
 msgid "Email Text for Reservation Autoapproved"
 msgstr "Email Text für Automatisch Angenommmene Reservationen"
 
-#: ./interfaces.py:656
+#: ./interfaces.py:672
 msgid "Email Text for Reservation Pending"
 msgstr "Email Text für Reservationen in der Warteliste"
 
-#: ./interfaces.py:710
+#: ./interfaces.py:726
 msgid "Email Text for Revoked Reservations"
 msgstr "Email Text für Abgesagte Reservationen"
 
 #: ./exports/reservations.py:47
-#: ./interfaces.py:519
+#: ./interfaces.py:532
 msgid "End"
 msgstr "Ende"
 
-#: ./interfaces.py:601
+#: ./interfaces.py:617
 msgid "End date before start date"
 msgstr "Ende vor Start"
 
@@ -367,11 +367,11 @@ msgstr "Ende vor Start"
 msgid "Entry"
 msgstr "Eintrag"
 
-#: ./interfaces.py:374
+#: ./interfaces.py:376
 msgid "Everything after this hour is not shown in the calendar, making the calendar display more compact. Should be set to an hour after which there cannot be any reservations."
 msgstr "Alles nach dieser Stunde wird im Kalender nicht angezeigt, was die Anzeige kompakter macht. Sie sollten eine Stunde wählen nach der es keine Reservationen geben kann."
 
-#: ./interfaces.py:362
+#: ./interfaces.py:364
 msgid "Everything before this hour is not shown in the calendar, making the calendar display more compact. Should be set to an hour before which there cannot be any reservations."
 msgstr "Alles vor dieser Stunde wird im Kalender nicht angezeigt, was die Anzeige kompakter macht. Sie sollten eine Stunde wählen vor der es keine Reservationen geben kann."
 
@@ -384,23 +384,23 @@ msgstr ""
 msgid "Export Reservations"
 msgstr ""
 
-#: ./interfaces.py:459
+#: ./interfaces.py:461
 msgid "First hour must be smaller than last hour"
 msgstr "Die erste volle Stunde muss kleiner als die letzte volle Stunde sein"
 
-#: ./interfaces.py:361
+#: ./interfaces.py:363
 msgid "First hour of the day"
 msgstr "Erste volle Stunde"
 
-#: ./reserve.py:1090
+#: ./reserve.py:1199
 msgid "Formdata updated"
 msgstr "Formdaten aktualisiert"
 
-#: ./interfaces.py:433
+#: ./interfaces.py:435
 msgid "Formsets"
 msgstr "Teilformulare"
 
-#: ./interfaces.py:52
+#: ./interfaces.py:54
 msgid "Fr"
 msgstr "Fr"
 
@@ -420,19 +420,19 @@ msgstr "Hat eine Warteliste"
 msgid "Hide"
 msgstr "Verstecken"
 
-#: ./interfaces.py:492
+#: ./interfaces.py:505
 msgid "Id"
 msgstr "Id"
 
-#: ./interfaces.py:295
+#: ./interfaces.py:297
 msgid "If checked a reservation manager must decide if a reservation can be approved. Until then users are added to a waitinglist. Reservations are automatically approved if this is not checked. "
 msgstr "Falls gewählt muss ein Reservations-Manager entscheiden ob eine Reservations-Anfrage angenommen wird. Bis dahin landen die Anfragen auf einer Warteliste. Ist diese Option nicht gewählt, werden Anfragen automatisch angenommen."
 
-#: ./interfaces.py:555
+#: ./interfaces.py:568
 msgid "If checked parts of the recurrance may be reserved. If not checked the recurrance must be reserved as a whole."
 msgstr ""
 
-#: ./interfaces.py:306
+#: ./interfaces.py:308
 msgid "If the allocation is partly available users may reserve only a part of it (e.g. half of it). If not the allocation Must be reserved as a whole or not at all"
 msgstr "Falls die Einteilung teilweise verfügbar ist, kann ein Benutzer einen einzelnen Zeitabschnitt der Einteilung reservieren. Falls nicht, muss die Einteilung über die gesamte Zeitdauer reserviert werden."
 
@@ -440,19 +440,19 @@ msgstr "Falls die Einteilung teilweise verfügbar ist, kann ein Benutzer einen e
 msgid "Invalid change. Your request may have already been processed earlier."
 msgstr "Ungültige Änderung. Ihre Anfrage wurde möglicherweise schon bearbeitet."
 
-#: ./interfaces.py:130
+#: ./interfaces.py:132
 msgid "Invalid email address"
 msgstr "Ungültige Email Adresse"
 
-#: ./interfaces.py:452
+#: ./interfaces.py:454
 msgid "Invalid first hour"
 msgstr "Ungültige erste volle Stunde"
 
-#: ./interfaces.py:455
+#: ./interfaces.py:457
 msgid "Invalid last hour"
 msgstr "Ungültige letzte volle Stunde"
 
-#: ./reserve.py:475
+#: ./reserve.py:476
 msgid "Invalid reservation request"
 msgstr ""
 
@@ -460,11 +460,11 @@ msgstr ""
 msgid "JSON Format"
 msgstr ""
 
-#: ./interfaces.py:628
+#: ./interfaces.py:644
 msgid "Language"
 msgstr "Sprache"
 
-#: ./interfaces.py:373
+#: ./interfaces.py:375
 msgid "Last hour of the day"
 msgstr "Letzte volle Stunde"
 
@@ -484,19 +484,19 @@ msgstr "Auflisten"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: ./interfaces.py:294
+#: ./interfaces.py:296
 msgid "Manually approve reservation requests"
 msgstr "Reservations-Anfragen manuell bestätigen"
 
-#: ./interfaces.py:618
+#: ./interfaces.py:634
 msgid "May contain the following template variable:<br>%(reservations)s - list of reservations"
 msgstr "Kann die folgenden Vorlagen-Variable enthalten:<br>%(reservations)s - Liste der Reservationen"
 
-#: ./interfaces.py:603
+#: ./interfaces.py:619
 msgid "May contain the following template variables:<br>%(resource)s - title of the resource<br>%(dates)s - list of dates reserved<br>%(reservation_mail)s - email of reservee<br>%(data)s - formdata associated with the reservation<br>%(approval_link)s - link to the approval view<br>%(denial_link)s - link to the denial view<br>%(cancel_link)s - link to the cancel view"
 msgstr "Kann die folgenden Vorlagen-Variabeln enthalten:<br>%(resource)s - Titel der Ressource<br>%(dates)s - Daten der Reservation<br>%(reservation_mail)s - Email des/der Reservierenden<br>%(data)s - Formulardaten der Reservation<br>%(approval_link)s - Link zu der Zulassungs-Ansicht<br>%(denial_link)s - Link zu der Ablehnungs-Ansicht<br>%(cancel_link)s - Link zur Absage-Ansicht"
 
-#: ./interfaces.py:48
+#: ./interfaces.py:50
 msgid "Mo"
 msgstr "Mo"
 
@@ -512,11 +512,11 @@ msgstr "Monatsreport"
 msgid "Monthly Report for ${month} ${year}"
 msgstr "Monatsreport ${month} ${year}"
 
-#: ./interfaces.py:67
+#: ./interfaces.py:69
 msgid "Monthly View"
 msgstr "Monatsansicht"
 
-#: ./interfaces.py:351
+#: ./interfaces.py:353
 msgid "Name"
 msgstr "Name"
 
@@ -532,10 +532,6 @@ msgstr "Nächster Monat &gt;&gt;"
 msgid "No"
 msgstr "Nein"
 
-#: ./reserve.py:1027
-msgid "No Formdata to edit"
-msgstr "Keine Formdaten zum Bearbeiten"
-
 #: ./error.py:134
 msgid "No reservable slot found."
 msgstr "Der gewünschte Zeitbereich ist bereits besetzt."
@@ -544,23 +540,23 @@ msgstr "Der gewünschte Zeitbereich ist bereits besetzt."
 msgid "No reserved slots would be left after this operation"
 msgstr ""
 
-#: ./reserve.py:730
+#: ./reserve.py:731
 msgid "No such reservation"
 msgstr "Unbekannte Reservation"
 
-#: ./interfaces.py:274
+#: ./interfaces.py:276
 msgid "Number of times an allocation may be reserved at the same time. e.g. 3 spots in a daycare center, 2 available cars, 1 meeting room. "
 msgstr "Legt das Kontingent der Einteilung fest. z.B. 3 Plätze in einer Kinderkrippe, 2 verfügbare Autos, 1 Besprechungszimmer"
 
-#: ./interfaces.py:60
+#: ./interfaces.py:62
 msgid "Once"
 msgstr "Ohne"
 
-#: ./utils.py:746
+#: ./utils.py:747
 msgid "One Person Waiting"
 msgstr "Eine Person wartet"
 
-#: ./interfaces.py:822
+#: ./interfaces.py:838
 msgid "Optional reason for the revocation. Sent to the reservee. e.g. 'Your reservation has to be cancelled because the lecturer is ill'."
 msgstr "Optionaler Grund für die Absage. Wird an den Reservierenden gesendet. Z.B. 'Ihre Reservation muss abesagt werden, weil der Dozent krank ist'."
 
@@ -568,13 +564,13 @@ msgstr "Optionaler Grund für die Absage. Wird an den Reservierenden gesendet. Z
 msgid "Parent"
 msgstr "Übergeordnetes Element"
 
-#: ./interfaces.py:305
+#: ./interfaces.py:307
 #: ./templates/resource.pt:60
 msgid "Partly available"
 msgstr "Teilweise verfügbar"
 
-#: ./allocate.py:146
-#: ./interfaces.py:577
+#: ./allocate.py:147
+#: ./interfaces.py:593
 msgid "Partly available allocations can only be reserved separately"
 msgstr "Teilweise verfügbare Einteilungen können nur separat reserviert werden"
 
@@ -587,32 +583,32 @@ msgstr "Warteliste"
 msgid "Pre-Reservation Script"
 msgstr "Pre-Reservations Skript"
 
-#: ./templates/macros.pt:140
+#: ./templates/macros.pt:142
 msgid "Print"
 msgstr "Drucken"
 
 #: ./exports/reservations.py:50
-#: ./interfaces.py:273
+#: ./interfaces.py:275
 msgid "Quota"
 msgstr "Kontingent"
 
-#: ./interfaces.py:330
+#: ./interfaces.py:332
 msgid "Quota must be between 1 and 1000"
 msgstr "Kontingent muss zwischen 1 und 1000 liegen"
 
-#: ./interfaces.py:316
+#: ./interfaces.py:318
 msgid "Raster"
 msgstr "Raster"
 
-#: ./interfaces.py:821
+#: ./interfaces.py:837
 msgid "Reason"
 msgstr "Grund"
 
-#: ./reserve.py:576
+#: ./reserve.py:577
 msgid "Recurrance reservation"
 msgstr "Wiederholung reservieren"
 
-#: ./interfaces.py:498
+#: ./interfaces.py:511
 msgid "Recurrence"
 msgstr "Wiederholung"
 
@@ -624,29 +620,37 @@ msgstr "Auflistung der Wiederholung"
 msgid "Recurrences"
 msgstr "Wiederholungen"
 
-#: ./reserve.py:845
+#: ./reserve.py:846
 #: ./resource.py:373
 #: ./templates/your_reservations_viewlet.pt:16
 msgid "Remove"
 msgstr "Entfernen"
 
-#: ./allocate.py:273
+#: ./allocate.py:274
 msgid "Remove allocations"
 msgstr "Einteilungen entfernen"
 
-#: ./reserve.py:801
+#: ./templates/macros.pt:212
+msgid "Remove future reservations"
+msgstr "Zukünftige Reservationen entfernen"
+
+#: ./templates/macros.pt:206
+msgid "Remove reservation"
+msgstr "Reservation entfernen"
+
+#: ./reserve.py:802
 msgid "Remove reservations"
 msgstr "Reservationen entfernen"
 
-#: ./interfaces.py:776
+#: ./interfaces.py:792
 msgid "Reservation"
 msgstr "Reservation"
 
-#: ./interfaces.py:749
+#: ./interfaces.py:765
 msgid "Reservation Quota"
 msgstr "Anzahl Reservationen"
 
-#: ./interfaces.py:284
+#: ./interfaces.py:286
 msgid "Reservation Quota Limit"
 msgstr "Limite der Anzahl Reservationen"
 
@@ -654,28 +658,28 @@ msgstr "Limite der Anzahl Reservationen"
 msgid "Reservation Throttling"
 msgstr "Reservations-Beschränkung"
 
-#: ./reserve.py:740
+#: ./reserve.py:741
 msgid "Reservation confirmed"
 msgstr "Reservation bestätigt"
 
-#: ./reserve.py:773
+#: ./reserve.py:774
 msgid "Reservation denied"
 msgstr "Reservation abgelehnt"
 
 #: ./error.py:147
-#: ./reserve.py:471
+#: ./reserve.py:472
 msgid "Reservation out of bounds"
 msgstr "Reservation ausserhalb des gültigen Bereichs"
 
-#: ./interfaces.py:336
+#: ./interfaces.py:338
 msgid "Reservation quota limit must zero or a positive number"
 msgstr "Limit der Anzahl Reservationen muss Null oder grösser sein"
 
-#: ./reserve.py:852
+#: ./reserve.py:853
 msgid "Reservation removed"
 msgstr "Reservation entfernt"
 
-#: ./reserve.py:925
+#: ./reserve.py:924
 msgid "Reservation revoked"
 msgstr "Reservation abgesagt"
 
@@ -696,7 +700,7 @@ msgstr ""
 msgid "Reservations (Normal)"
 msgstr ""
 
-#: ./reserve.py:647
+#: ./reserve.py:648
 msgid "Reservations Successfully Submitted"
 msgstr "Reservierung erfolgreich abgeschlossen"
 
@@ -708,12 +712,12 @@ msgstr "Reservationen können nicht über mehr als 24 Stunden gemacht werden"
 msgid "Reservations in the last 30 days"
 msgstr ""
 
-#: ./reserve.py:514
+#: ./reserve.py:515
 #: ./resource.py:342
 msgid "Reserve"
 msgstr "Reservieren"
 
-#: ./reserve.py:651
+#: ./reserve.py:652
 msgid "Reserve More"
 msgstr "Weitere Reservationen"
 
@@ -730,12 +734,12 @@ msgstr "Reservation"
 msgid "Resources"
 msgstr "Ressourcen"
 
-#: ./reserve.py:917
-#: ./templates/macros.pt:123
+#: ./reserve.py:916
+#: ./templates/macros.pt:125
 msgid "Revoke"
 msgstr "Absagen"
 
-#: ./reserve.py:904
+#: ./reserve.py:903
 msgid "Revoke reservation"
 msgstr "Reservation absagen"
 
@@ -743,12 +747,12 @@ msgstr "Reservation absagen"
 msgid "Run custom validation code for reservations. This is for advanced users only and may disable the reservations process. For documentation study the source code at Github."
 msgstr ""
 
-#: ./interfaces.py:53
+#: ./interfaces.py:55
 msgid "Sa"
 msgstr "Sa"
 
-#: ./mail.py:447
-#: ./reserve.py:1081
+#: ./mail.py:482
+#: ./reserve.py:1178
 #: ./timeframe.py:83
 msgid "Save"
 msgstr "Speichern"
@@ -761,27 +765,27 @@ msgstr "Seantis Reservation Kontrollzentrum"
 msgid "Seantis Reservation Settings"
 msgstr "Seantis Reservation Einstellungen"
 
-#: ./interfaces.py:87
+#: ./interfaces.py:89
 msgid "Select at least one value"
 msgstr "Bitte wählen Sie mindestens einen Wert"
 
-#: ./interfaces.py:408
+#: ./interfaces.py:410
 msgid "Selected Date"
 msgstr "Ausgewähltes Datum"
 
-#: ./interfaces.py:398
+#: ./interfaces.py:400
 msgid "Selected View"
 msgstr "Ausgewählte Ansicht"
 
-#: ./interfaces.py:399
+#: ./interfaces.py:401
 msgid "Selected view when opening the calendar."
 msgstr "Ansicht die beim Öffnen des Kalenders angezeigt wird."
 
-#: ./interfaces.py:813
+#: ./interfaces.py:829
 msgid "Send Email"
 msgstr ""
 
-#: ./interfaces.py:814
+#: ./interfaces.py:830
 msgid "Send an email to the reservee informing him of the revocation"
 msgstr ""
 
@@ -797,35 +801,35 @@ msgstr "Sende Emails zu neuen Reservationen in der Warteliste zum ersten Reserva
 msgid "Send emails about newly made reservations to the first reservation managers found in the path."
 msgstr "Sende Emails zu neuen Reservationen zum ersten Reservationsmanager der im Pfad gefunden werden kann."
 
-#: ./interfaces.py:648
+#: ./interfaces.py:664
 msgid "Sent to <b>managers</b> when a new pending reservation is made. May contain the template variables listed below."
 msgstr "Wird <b>Managern</b> gesendet, wenn eine Reservation in die Warteliste hinzugefügt wird. Kann die untenstehenden Vorlagen-Variabeln enthalten."
 
-#: ./interfaces.py:634
+#: ./interfaces.py:650
 msgid "Sent to <b>managers</b> when a reservation is automatically approved. May contain the template variables listed below."
 msgstr "Wird <b>Managern</b> gesendet, wenn eine Reservation automatisch angenommen wurde. Kann die untenstehenden Vorlagen-Variabeln enthalten."
 
-#: ./interfaces.py:663
+#: ./interfaces.py:679
 msgid "Sent to <b>users</b> when a new pending reservation is made. May contain the template variables listed below."
 msgstr "Wird <b>Benutzern</b> gesendet, wenn eine neue Reservation in die Warteliste hinzugefügt wird. Kann die untenstehenden Vorlagen-Variabeln enthalten."
 
-#: ./interfaces.py:678
+#: ./interfaces.py:694
 msgid "Sent to <b>users</b> when a reservation is approved. May contain the template variables listed below."
 msgstr "Wird <b>Benutzern</b> gesendet, wenn eine Reservation zugelassen wird. Kann die untenstehenden Vorlagen-Variabeln enthalten."
 
-#: ./interfaces.py:691
+#: ./interfaces.py:707
 msgid "Sent to <b>users</b> when a reservation is denied. May contain the template variables listed below."
 msgstr "Wird <b>Benutzern</b> gesendet, wenn eine Reservation abgelehnt wird. Kann die untenstehenden Vorlagen-Variabeln enthalten."
 
-#: ./interfaces.py:704
+#: ./interfaces.py:720
 msgid "Sent to <b>users</b> when a reservation is revoked. May contain the template variables listed below."
 msgstr "Wird <b>Benutzern</b> gesenet, wenn eine Reservation abgesagt wird. Kann die untenstehenden Vorlagen-Variabeln enthalten."
 
-#: ./interfaces.py:554
+#: ./interfaces.py:567
 msgid "Separately reservable"
 msgstr "Separat reservierbar"
 
-#: ./allocate.py:184
+#: ./allocate.py:185
 msgid "Settings"
 msgstr "Einstellungen"
 
@@ -833,12 +837,12 @@ msgstr "Einstellungen"
 msgid "Show"
 msgstr "Anzeigen"
 
-#: ./interfaces.py:418
+#: ./interfaces.py:420
 msgid "Specific Date"
 msgstr "Bestimmtes Datum"
 
 #: ./exports/reservations.py:46
-#: ./interfaces.py:510
+#: ./interfaces.py:523
 msgid "Start"
 msgstr "Start"
 
@@ -850,19 +854,19 @@ msgstr "Status"
 msgid "Statuses"
 msgstr "Stati"
 
-#: ./interfaces.py:54
+#: ./interfaces.py:56
 msgid "Su"
 msgstr "So"
 
-#: ./interfaces.py:434
+#: ./interfaces.py:436
 msgid "Subforms that need to be filled out to make a reservation. Forms can currently only be created by a site-administrator."
 msgstr "Unterformulare die ausgefüllt werden müssen um eine Reservation zu machen. Unterformulare können zur Zeit nur durch Administratoren erstellt werden."
 
-#: ./reserve.py:643
+#: ./reserve.py:644
 msgid "Submit Reservations"
 msgstr "Bestätigen und abschliessen"
 
-#: ./interfaces.py:51
+#: ./interfaces.py:53
 msgid "Th"
 msgstr "Do"
 
@@ -870,11 +874,11 @@ msgstr "Do"
 msgid "The allocation does not have enough spots to possibly satisfy the requested reservation quota."
 msgstr "Die Einteilung hat nicht genug Plätze um die verlangte Anzahl zu reservieren."
 
-#: ./interfaces.py:571
+#: ./interfaces.py:587
 msgid "The allocation must be at least 5 minutes long"
 msgstr "Die Einteilung muss mindestens 5 minuten lang sein"
 
-#: ./interfaces.py:531
+#: ./interfaces.py:544
 msgid "The allocation spans the whole day."
 msgstr "Die Einteilung ist für den ganzen Tag gültig."
 
@@ -894,7 +898,7 @@ msgstr "Das Reservations-Token ist ungültig."
 msgid "The item does no longer exist."
 msgstr "Der Eintrag existiert nicht mehr"
 
-#: ./interfaces.py:285
+#: ./interfaces.py:287
 msgid "The maximum quota a single reservation may occupy at once. There is no limit if set to zero."
 msgstr "Die maximale Anzahl die eine einzelne Reservation auf einmal bsetzen kann. Null wenn kein Limit."
 
@@ -930,7 +934,7 @@ msgstr "Die Resource wird von jemand anderem bearbeitet. Bitte versuchen Sie es 
 msgid "The resulting allocation would be invalid"
 msgstr "Die resultierende Einteilung wäre Ungültig"
 
-#: ./interfaces.py:474
+#: ./interfaces.py:476
 msgid "The selected view must be one of the available views."
 msgstr "Die ausgewählte Ansicht muss eine verfügbare Ansicht sein."
 
@@ -942,7 +946,7 @@ msgstr "${nb} Reservationen werden gerade eingegeben."
 msgid "There is one reservation being entered for this resource."
 msgstr "Eine Reservation wird gerade eingegeben."
 
-#: ./mail.py:432
+#: ./mail.py:467
 msgid "There's already an Email template in the same folder for the same language"
 msgstr "Es besteht bereits eine Email Vorlage mit dieser Sprache in diesem Order"
 
@@ -958,7 +962,7 @@ msgstr "Belegungsperiode"
 msgid "Timeframe overlaps with '${overlap}' in the current folder"
 msgstr "Die Belegungsperiod überschneidet sich mit '${overlap}' in diesem Ordner"
 
-#: ./interfaces.py:504
+#: ./interfaces.py:517
 #: ./templates/timeframes.pt:4
 msgid "Timeframes"
 msgstr "Belegungsperioden"
@@ -979,7 +983,7 @@ msgstr "Token"
 msgid "Too many reservations in a short time. Wait for a moment before trying again."
 msgstr "Zu viele Reservationen in einer kurzen Zeit. Bitte warten Sie für einen Moment und versuchen Sie es dann noch einmal."
 
-#: ./interfaces.py:49
+#: ./interfaces.py:51
 msgid "Tu"
 msgstr "Di"
 
@@ -991,11 +995,11 @@ msgstr "Nicht verfügbar"
 msgid "Utils"
 msgstr "Hilfsmittel"
 
-#: ./interfaces.py:386
+#: ./interfaces.py:388
 msgid "Views available to the user on the calendar."
 msgstr "Ansichten die den Benutzern auf dem Kalender zur verfügung stehen."
 
-#: ./interfaces.py:761
+#: ./interfaces.py:777
 msgid "Visible on the calendar"
 msgstr ""
 
@@ -1003,20 +1007,20 @@ msgstr ""
 msgid "Waitinglist"
 msgstr "Warteliste"
 
-#: ./utils.py:744
+#: ./utils.py:745
 msgid "Waitinglist is Free"
 msgstr "Warteliste Frei"
 
-#: ./interfaces.py:50
+#: ./interfaces.py:52
 msgid "We"
 msgstr "Mi"
 
-#: ./interfaces.py:68
+#: ./interfaces.py:70
 msgid "Weekly View"
 msgstr "Wochenansicht"
 
 #: ./exports/reservations.py:48
-#: ./interfaces.py:530
+#: ./interfaces.py:543
 #: ./resource.py:437
 msgid "Whole Day"
 msgstr "Ganztägig"
@@ -1029,7 +1033,7 @@ msgstr "Ja"
 msgid "Yesterday, at ${time}"
 msgstr "Gestern, um ${time}"
 
-#: ./interfaces.py:466
+#: ./interfaces.py:468
 msgid "You chose to 'Always show a specific date' but you did not specify a specific date"
 msgstr "Sie möchten 'Immer ein bestimmtes Datum anzeigen' haben aber kein Datum bestimmt"
 
@@ -1037,4 +1041,9 @@ msgstr "Sie möchten 'Immer ein bestimmtes Datum anzeigen' haben aber kein Datum
 #: ./templates/your_reservations_viewlet.pt:10
 msgid "Your reservations"
 msgstr "Ihre Reservationen"
+
+#. Default: "Please specify a valid time, for example 09:00"
+#: ./converter.py:47
+msgid "msg_error_time_value"
+msgstr "Bitte geben Sie eine gültige Uhrzeit an, z.B. 09:00"
 

--- a/seantis/reservation/locales/fr/LC_MESSAGES/seantis.reservation.po
+++ b/seantis/reservation/locales/fr/LC_MESSAGES/seantis.reservation.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-10-28 16:18+0000\n"
+"POT-Creation-Date: 2013-11-12 12:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -9,6 +9,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
@@ -20,23 +22,23 @@ msgstr ""
 msgid "${days} days ago, at ${time}"
 msgstr ""
 
-#: ./interfaces.py:614
+#: ./interfaces.py:630
 msgid "%(reason)s - reason for revocation<br>"
 msgstr "%(reason)s à justifier pour retirer l'info<br>"
 
-#: ./utils.py:748
+#: ./utils.py:749
 msgid "%i People Waiting"
 msgstr "%i En attente"
 
-#: ./utils.py:729
+#: ./utils.py:730
 msgid "%i%% Free"
 msgstr "%i%% Libre"
 
-#: ./utils.py:736
+#: ./utils.py:737
 msgid "%i/%i Spot Available"
 msgstr "%i/%i Place disponible"
 
-#: ./utils.py:732
+#: ./utils.py:733
 msgid "%i/%i Spots Available"
 msgstr "%i/%i Places disponibles"
 
@@ -44,15 +46,15 @@ msgstr "%i/%i Places disponibles"
 msgid "&lt;&lt; Previous Month"
 msgstr "&lt;&lt; Mois précédent"
 
-#: ./templates/macros.pt:175
+#: ./templates/macros.pt:177
 msgid "&raquo; Edit Formdata"
 msgstr "&raquo; Modifier dates form"
 
-#: ./utils.py:587
+#: ./utils.py:588
 msgid "<b>${quota}</b> reservations"
 msgstr "<b>${quota}</b> Réservations"
 
-#: ./utils.py:589
+#: ./utils.py:590
 msgid "<b>1</b> reservation"
 msgstr "<b>1</b> Réservation"
 
@@ -64,7 +66,7 @@ msgstr "Il existe déjà une périodisation pour le temps choisi"
 msgid "A pending reservation would be affected by the requested change"
 msgstr "Une réservation actuellement ouverte serait impliquée par ce changement"
 
-#: ./mail.py:495
+#: ./mail.py:530
 msgid "Add email template"
 msgstr "Template courriel à ajouter"
 
@@ -88,35 +90,35 @@ msgstr "Périodiser"
 msgid "Allocation"
 msgstr "Périodisation"
 
-#: ./interfaces.py:785
+#: ./interfaces.py:801
 msgid "Allocation Id"
 msgstr "Allocations ID"
 
-#: ./allocate.py:132
+#: ./allocate.py:133
 msgid "Allocation added"
 msgstr "Périodisation ajoutée"
 
-#: ./allocate.py:294
+#: ./allocate.py:295
 msgid "Allocation removed"
 msgstr "Périodisation supprimée"
 
-#: ./allocate.py:251
+#: ./allocate.py:252
 msgid "Allocation saved"
 msgstr "Périodisation enregistrée"
 
-#: ./interfaces.py:520
+#: ./interfaces.py:533
 msgid "Allocations may end every 5 minutes if the allocation is not partly available. If it is partly available the start time may be every x minute where x equals the given raster. The minimum length of an allocation is also either 5 minutes or whatever the value of the raster is."
 msgstr "Périodisation peut se faire toutes les cinq minutes (horaire). Si l'option choisie est \"partiellement disponible\", l’option retenue sera de x"
 
-#: ./interfaces.py:511
+#: ./interfaces.py:524
 msgid "Allocations may start every 5 minutes if the allocation is not partly available. If it is partly available the start time may be every x minute where x equals the given raster."
 msgstr "Périodisation peut commencer toutes les cinq minutes (horaire). Si l'option choisie est \"partiellement disponible\", l’option retenue sera de x"
 
-#: ./interfaces.py:79
+#: ./interfaces.py:81
 msgid "Always show a specific date"
 msgstr "Afficher toujours une date particulière"
 
-#: ./interfaces.py:78
+#: ./interfaces.py:80
 msgid "Always show the current date"
 msgstr "Afficher toujours la date actuelle"
 
@@ -129,12 +131,12 @@ msgid "Approval Email Notifications for Managers"
 msgstr "Notification par courriel aux responsables des réservations pour des réservations à confirmer"
 
 #: ./reports/monthly_report.py:226
-#: ./reserve.py:734
-#: ./templates/macros.pt:134
+#: ./reserve.py:735
+#: ./templates/macros.pt:136
 msgid "Approve"
 msgstr "Approuver"
 
-#: ./reserve.py:725
+#: ./reserve.py:726
 msgid "Approve reservation"
 msgstr "Approuver la réservation"
 
@@ -143,7 +145,7 @@ msgstr "Approuver la réservation"
 msgid "Approved"
 msgstr "Approuvée"
 
-#: ./interfaces.py:385
+#: ./interfaces.py:387
 msgid "Available Views"
 msgstr "Vues disponibles"
 
@@ -151,7 +153,7 @@ msgstr "Vues disponibles"
 msgid "CSV Format"
 msgstr ""
 
-#: ./interfaces.py:409
+#: ./interfaces.py:411
 msgid "Calendar date shown when opening the calendar."
 msgstr "Les disponibilités sont présentées dès l'ouverture du calendrier"
 
@@ -159,8 +161,8 @@ msgstr "Les disponibilités sont présentées dès l'ouverture du calendrier"
 msgid "Can't block period because a reservation already exists."
 msgstr "Cette période ne peut pas être bloqué comme une réservation existe déjà"
 
-#: ./allocate.py:151
-#: ./reserve.py:538
+#: ./allocate.py:152
+#: ./reserve.py:539
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -176,7 +178,7 @@ msgstr "Réservation"
 msgid "Compare Resources"
 msgstr "Comparer les différentes options"
 
-#: ./templates/macros.pt:191
+#: ./templates/macros.pt:193
 msgid "Concerned Dates"
 msgstr "Dates demandées"
 
@@ -188,15 +190,15 @@ msgstr "Terminer les réservations"
 msgid "Created"
 msgstr ""
 
-#: ./interfaces.py:341
+#: ./interfaces.py:343
 msgid "DEPRECATED: Approve reservation requests"
 msgstr "DEPRECATED: Valider la demande de réservation"
 
-#: ./interfaces.py:61
+#: ./interfaces.py:63
 msgid "Daily"
 msgstr "Quotidiennement"
 
-#: ./interfaces.py:69
+#: ./interfaces.py:71
 msgid "Daily View"
 msgstr "Vue par jour"
 
@@ -204,39 +206,39 @@ msgstr "Vue par jour"
 msgid "Date"
 msgstr "Date"
 
-#: ./interfaces.py:544
+#: ./interfaces.py:557
 msgid "Day"
 msgstr "Jour"
 
-#: ./interfaces.py:548
+#: ./interfaces.py:561
 msgid "Days"
 msgstr "Jours"
 
-#: ./interfaces.py:424
+#: ./interfaces.py:426
 msgid "Default Allocation Values"
 msgstr "Classification standard"
 
-#: ./interfaces.py:317
+#: ./interfaces.py:319
 msgid "Defines the minimum length of any given reservation as well as the alignment of the start / end of the allocation. E.g. a raster of 30 minutes means that the allocation can only start at xx:00 and xx:30 respectively"
 msgstr "Définir la durée minimum de chaque réservation ainsi que le début / la fin de la période de la réservation, par ex. une durée de 30 minutes signifie que la réservation peut seulement commencer à xx:00 ou à xx:30 "
 
-#: ./allocate.py:278
-#: ./mail.py:504
+#: ./allocate.py:279
+#: ./mail.py:539
 #: ./reports/monthly_report.py:220
 msgid "Delete"
 msgstr "Supprimer"
 
 #: ./reports/monthly_report.py:232
-#: ./reserve.py:767
-#: ./templates/macros.pt:130
+#: ./reserve.py:768
+#: ./templates/macros.pt:132
 msgid "Deny"
 msgstr "Refuser"
 
-#: ./reserve.py:758
+#: ./reserve.py:759
 msgid "Deny reservation"
 msgstr "Refuser la réservation"
 
-#: ./interfaces.py:355
+#: ./interfaces.py:357
 msgid "Description"
 msgstr "Description"
 
@@ -244,11 +246,11 @@ msgstr "Description"
 msgid "Details"
 msgstr "Détails"
 
-#: ./reserve.py:732
+#: ./reserve.py:733
 msgid "Do you really want to approve the following reservations?"
 msgstr "Voulez-vous vraiment effectuer cette réservation?"
 
-#: ./reserve.py:765
+#: ./reserve.py:766
 msgid "Do you really want to deny the following reservations?"
 msgstr "Voulez-vous vraiment annuler cette réservation?"
 
@@ -256,11 +258,11 @@ msgstr "Voulez-vous vraiment annuler cette réservation?"
 msgid "Do you really want to remove the following allocations?"
 msgstr "Voulez-vous vraiment supprimer ces périodisations?"
 
-#: ./reserve.py:841
+#: ./reserve.py:842
 msgid "Do you really want to remove the following reservations?"
 msgstr "Voulez-vous vraiment supprimer ces réservations?"
 
-#: ./reserve.py:913
+#: ./reserve.py:912
 msgid "Do you really want to revoke the following reservations?"
 msgstr "Voulez-vous vraiment supprimer cette réservation?"
 
@@ -268,22 +270,22 @@ msgstr "Voulez-vous vraiment supprimer cette réservation?"
 msgid "Do you want to reserve the following allocations?"
 msgstr "Voulez-vous vraiment réserver comme indiqué?"
 
-#: ./allocate.py:223
-#: ./mail.py:503
+#: ./allocate.py:224
+#: ./mail.py:538
 #: ./resource.py:369
 msgid "Edit"
 msgstr "Modifier"
 
-#: ./reserve.py:1025
-msgid "Edit Formdata"
-msgstr "Modifier données du formulaire"
-
-#: ./allocate.py:173
+#: ./allocate.py:174
 msgid "Edit allocation"
 msgstr "Modifier la périodisation"
 
+#: ./reserve.py:1029
+msgid "Edit reservation"
+msgstr ""
+
 #: ./exports/reservations.py:45
-#: ./interfaces.py:145
+#: ./interfaces.py:147
 msgid "Email"
 msgstr "Courriel"
 
@@ -295,31 +297,31 @@ msgstr "Courriel pour le responsable"
 msgid "Email Notifications for Reservees"
 msgstr "Courriel pour la personne qui a réservé"
 
-#: ./interfaces.py:677
+#: ./interfaces.py:693
 msgid "Email Subject for Approved Reservations"
 msgstr "Courriel de confirmation de réservation"
 
-#: ./interfaces.py:690
+#: ./interfaces.py:706
 msgid "Email Subject for Denied Reservations"
 msgstr "Courriel d'annulation de réservation"
 
-#: ./interfaces.py:662
+#: ./interfaces.py:678
 msgid "Email Subject for Received Reservations"
 msgstr "Courriel de confirmation pour la réservation reçue"
 
-#: ./interfaces.py:633
+#: ./interfaces.py:649
 msgid "Email Subject for Reservation Autoapproved"
 msgstr "Courriel automatique de confirmation de réservation"
 
-#: ./interfaces.py:647
+#: ./interfaces.py:663
 msgid "Email Subject for Reservation Pending"
 msgstr "Courriel de réservation en attente"
 
-#: ./interfaces.py:703
+#: ./interfaces.py:719
 msgid "Email Subject for Revoked Reservations"
 msgstr "Courriel d'annulation de réservation"
 
-#: ./mail.py:96
+#: ./mail.py:115
 #: ./profiles/default/types/seantis.reservation.emailtemplate.xml
 msgid "Email Template"
 msgstr "Courriel présentation"
@@ -328,36 +330,36 @@ msgstr "Courriel présentation"
 msgid "Email Templates"
 msgstr "Courriel des présentations"
 
-#: ./interfaces.py:684
+#: ./interfaces.py:700
 msgid "Email Text for Approved Reservations"
 msgstr "Texte courriel pour la confirmation de la réservation"
 
-#: ./interfaces.py:697
+#: ./interfaces.py:713
 msgid "Email Text for Denied Reservations"
 msgstr "Texte courriel pour l'annulation de la réservation / l'annulation des réservations"
 
-#: ./interfaces.py:671
+#: ./interfaces.py:687
 msgid "Email Text for Received Reservations"
 msgstr "Texte courriel pour la réservation reçue"
 
-#: ./interfaces.py:641
+#: ./interfaces.py:657
 msgid "Email Text for Reservation Autoapproved"
 msgstr "Texte courriel automatique pour la confirmation de réservation"
 
-#: ./interfaces.py:656
+#: ./interfaces.py:672
 msgid "Email Text for Reservation Pending"
 msgstr "Texte courriel de réservation en attente"
 
-#: ./interfaces.py:710
+#: ./interfaces.py:726
 msgid "Email Text for Revoked Reservations"
 msgstr "Texte courriel pour l'annulation de la réservation/ l'annulation des réservations"
 
 #: ./exports/reservations.py:47
-#: ./interfaces.py:519
+#: ./interfaces.py:532
 msgid "End"
 msgstr "Fin"
 
-#: ./interfaces.py:601
+#: ./interfaces.py:617
 msgid "End date before start date"
 msgstr "Fin avant début"
 
@@ -365,11 +367,11 @@ msgstr "Fin avant début"
 msgid "Entry"
 msgstr "Entrée"
 
-#: ./interfaces.py:374
+#: ./interfaces.py:376
 msgid "Everything after this hour is not shown in the calendar, making the calendar display more compact. Should be set to an hour after which there cannot be any reservations."
 msgstr "Tout ce qui figure après cette heure n'apparaît pas sur le calendrier. Choisir une option de présentation plus compact qui intègre la dernière heure après qu'il soit possible de réserver"
 
-#: ./interfaces.py:362
+#: ./interfaces.py:364
 msgid "Everything before this hour is not shown in the calendar, making the calendar display more compact. Should be set to an hour before which there cannot be any reservations."
 msgstr "Tout ce qui figure avant cette heure n'apparaît pas sur le calendrier. Choisir une option de présentation plus compact qui intègre la première heure avant qu'il soit possible de réserver"
 
@@ -382,23 +384,23 @@ msgstr ""
 msgid "Export Reservations"
 msgstr ""
 
-#: ./interfaces.py:459
+#: ./interfaces.py:461
 msgid "First hour must be smaller than last hour"
 msgstr "La première heure pleine doit être plus courte que la dernière heure"
 
-#: ./interfaces.py:361
+#: ./interfaces.py:363
 msgid "First hour of the day"
 msgstr "Première heure pleine"
 
-#: ./reserve.py:1090
+#: ./reserve.py:1199
 msgid "Formdata updated"
 msgstr "Données du formulaire actualisées"
 
-#: ./interfaces.py:433
+#: ./interfaces.py:435
 msgid "Formsets"
 msgstr "Formulaire / Sous-formulaire"
 
-#: ./interfaces.py:52
+#: ./interfaces.py:54
 msgid "Fr"
 msgstr "Ve"
 
@@ -418,19 +420,19 @@ msgstr "Il existe une liste d'attente"
 msgid "Hide"
 msgstr "Cacher"
 
-#: ./interfaces.py:492
+#: ./interfaces.py:505
 msgid "Id"
 msgstr "ld"
 
-#: ./interfaces.py:295
+#: ./interfaces.py:297
 msgid "If checked a reservation manager must decide if a reservation can be approved. Until then users are added to a waitinglist. Reservations are automatically approved if this is not checked. "
 msgstr "La gestion immobilière doit définir si une réservation peut être approuvée. Jusqu'à la validation de la réservation, les utilisateurs sont sur une liste d'attente. Les réservations sont automatiquement approuvées si ce n'est pas contrôlé. "
 
-#: ./interfaces.py:555
+#: ./interfaces.py:568
 msgid "If checked parts of the recurrance may be reserved. If not checked the recurrance must be reserved as a whole."
 msgstr ""
 
-#: ./interfaces.py:306
+#: ./interfaces.py:308
 msgid "If the allocation is partly available users may reserve only a part of it (e.g. half of it). If not the allocation Must be reserved as a whole or not at all"
 msgstr "Si les ressources demandées sont partiellement disponibles, les utilisateurs peuvent en réserver seulement une partie. Si ce n'est pas possible, il faut réserver l'intégralité ou pas du tout"
 
@@ -438,19 +440,19 @@ msgstr "Si les ressources demandées sont partiellement disponibles, les utilisa
 msgid "Invalid change. Your request may have already been processed earlier."
 msgstr "Modification impossible. Votre demande sera traitée aussi rapidement que possible."
 
-#: ./interfaces.py:130
+#: ./interfaces.py:132
 msgid "Invalid email address"
 msgstr "Adresse courriel incorrecte"
 
-#: ./interfaces.py:452
+#: ./interfaces.py:454
 msgid "Invalid first hour"
 msgstr "Première heure de réservation incorrecte"
 
-#: ./interfaces.py:455
+#: ./interfaces.py:457
 msgid "Invalid last hour"
 msgstr "Dernière heure de réservation incorrecte"
 
-#: ./reserve.py:475
+#: ./reserve.py:476
 msgid "Invalid reservation request"
 msgstr ""
 
@@ -458,11 +460,11 @@ msgstr ""
 msgid "JSON Format"
 msgstr ""
 
-#: ./interfaces.py:628
+#: ./interfaces.py:644
 msgid "Language"
 msgstr "Langue"
 
-#: ./interfaces.py:373
+#: ./interfaces.py:375
 msgid "Last hour of the day"
 msgstr "Dernière heure possible"
 
@@ -482,19 +484,19 @@ msgstr "Afficher"
 msgid "Manage"
 msgstr "Gérer"
 
-#: ./interfaces.py:294
+#: ./interfaces.py:296
 msgid "Manually approve reservation requests"
 msgstr "Les réservations doivent être confirmer manuellement"
 
-#: ./interfaces.py:618
+#: ./interfaces.py:634
 msgid "May contain the following template variable:<br>%(reservations)s - list of reservations"
 msgstr "Peut contenir les variables suivantes: <br>%(reservation)s - Liste des réservations"
 
-#: ./interfaces.py:603
+#: ./interfaces.py:619
 msgid "May contain the following template variables:<br>%(resource)s - title of the resource<br>%(dates)s - list of dates reserved<br>%(reservation_mail)s - email of reservee<br>%(data)s - formdata associated with the reservation<br>%(approval_link)s - link to the approval view<br>%(denial_link)s - link to the denial view<br>%(cancel_link)s - link to the cancel view"
 msgstr "Peut contenir les variables suivantes:<br>%(resource)s – Titre de la ressource<br>%(dates)s – dates de la réservation<br>%(reservation_mail)s – Adresse courriel de la personne qui réserve<br>%(data)s – Données du formulaire de la réservation<br>%(approval_link)s – Lien à l’affichage de la confirmation<br>%(denial_link)s - Lien à l’affichage du refus<br>%(cancel_link)s - Lien à l’affichage de la réponse négative"
 
-#: ./interfaces.py:48
+#: ./interfaces.py:50
 msgid "Mo"
 msgstr "Lu"
 
@@ -510,11 +512,11 @@ msgstr "Rapport mensuel"
 msgid "Monthly Report for ${month} ${year}"
 msgstr "Rapport mensuel pour ${month} ${year}"
 
-#: ./interfaces.py:67
+#: ./interfaces.py:69
 msgid "Monthly View"
 msgstr "Vue mensuelle"
 
-#: ./interfaces.py:351
+#: ./interfaces.py:353
 msgid "Name"
 msgstr "Nom"
 
@@ -530,10 +532,6 @@ msgstr "Mois suivant &gt;&gt;"
 msgid "No"
 msgstr "Non"
 
-#: ./reserve.py:1027
-msgid "No Formdata to edit"
-msgstr "Aucune données du formulaire à modifier"
-
 #: ./error.py:134
 msgid "No reservable slot found."
 msgstr "La période de réservation désirée est actuellement déjà occupée."
@@ -542,23 +540,23 @@ msgstr "La période de réservation désirée est actuellement déjà occupée."
 msgid "No reserved slots would be left after this operation"
 msgstr ""
 
-#: ./reserve.py:730
+#: ./reserve.py:731
 msgid "No such reservation"
 msgstr "Réservation inconnue"
 
-#: ./interfaces.py:274
+#: ./interfaces.py:276
 msgid "Number of times an allocation may be reserved at the same time. e.g. 3 spots in a daycare center, 2 available cars, 1 meeting room. "
 msgstr "Le nombre de fois qu'une réservation peut être faite en même temps, par exemple…"
 
-#: ./interfaces.py:60
+#: ./interfaces.py:62
 msgid "Once"
 msgstr "Sans"
 
-#: ./utils.py:746
+#: ./utils.py:747
 msgid "One Person Waiting"
 msgstr "Personne en attente"
 
-#: ./interfaces.py:822
+#: ./interfaces.py:838
 msgid "Optional reason for the revocation. Sent to the reservee. e.g. 'Your reservation has to be cancelled because the lecturer is ill'."
 msgstr "Mentionner la raison de l'annulation - optionnel  "
 
@@ -566,13 +564,13 @@ msgstr "Mentionner la raison de l'annulation - optionnel  "
 msgid "Parent"
 msgstr "Elément du niveau supérieur"
 
-#: ./interfaces.py:305
+#: ./interfaces.py:307
 #: ./templates/resource.pt:60
 msgid "Partly available"
 msgstr "Partiellement disponible"
 
-#: ./allocate.py:146
-#: ./interfaces.py:577
+#: ./allocate.py:147
+#: ./interfaces.py:593
 msgid "Partly available allocations can only be reserved separately"
 msgstr "Partiellement disponible. La salle peut être seulement réservée de manière séparée."
 
@@ -585,32 +583,32 @@ msgstr "Liste d'attente"
 msgid "Pre-Reservation Script"
 msgstr ""
 
-#: ./templates/macros.pt:140
+#: ./templates/macros.pt:142
 msgid "Print"
 msgstr ""
 
 #: ./exports/reservations.py:50
-#: ./interfaces.py:273
+#: ./interfaces.py:275
 msgid "Quota"
 msgstr "Contingent / Nombre de personnes"
 
-#: ./interfaces.py:330
+#: ./interfaces.py:332
 msgid "Quota must be between 1 and 1000"
 msgstr "Le nombre de personnes doit être situé entre 1 et 1000"
 
-#: ./interfaces.py:316
+#: ./interfaces.py:318
 msgid "Raster"
 msgstr "Grille"
 
-#: ./interfaces.py:821
+#: ./interfaces.py:837
 msgid "Reason"
 msgstr "Raison"
 
-#: ./reserve.py:576
+#: ./reserve.py:577
 msgid "Recurrance reservation"
 msgstr "Répétition de la réservation"
 
-#: ./interfaces.py:498
+#: ./interfaces.py:511
 msgid "Recurrence"
 msgstr "Répétition"
 
@@ -622,29 +620,37 @@ msgstr "Affichage de la répétition"
 msgid "Recurrences"
 msgstr "Répétitions"
 
-#: ./reserve.py:845
+#: ./reserve.py:846
 #: ./resource.py:373
 #: ./templates/your_reservations_viewlet.pt:16
 msgid "Remove"
 msgstr "Supprimer"
 
-#: ./allocate.py:273
+#: ./allocate.py:274
 msgid "Remove allocations"
 msgstr "Supprimer les périodisations non compatibles"
 
-#: ./reserve.py:801
+#: ./templates/macros.pt:212
+msgid "Remove future reservations"
+msgstr "Supprimer les futures réservations"
+
+#: ./templates/macros.pt:206
+msgid "Remove reservation"
+msgstr "Supprimer la réservation"
+
+#: ./reserve.py:802
 msgid "Remove reservations"
 msgstr "Supprimer les réservations"
 
-#: ./interfaces.py:776
+#: ./interfaces.py:792
 msgid "Reservation"
 msgstr "Réservation"
 
-#: ./interfaces.py:749
+#: ./interfaces.py:765
 msgid "Reservation Quota"
 msgstr "Nombre de réservations"
 
-#: ./interfaces.py:284
+#: ./interfaces.py:286
 msgid "Reservation Quota Limit"
 msgstr "Limiter le nombre de réservations"
 
@@ -652,28 +658,28 @@ msgstr "Limiter le nombre de réservations"
 msgid "Reservation Throttling"
 msgstr "Restriction de la réservation"
 
-#: ./reserve.py:740
+#: ./reserve.py:741
 msgid "Reservation confirmed"
 msgstr "Réservation confirmée"
 
-#: ./reserve.py:773
+#: ./reserve.py:774
 msgid "Reservation denied"
 msgstr "Réservation refusée"
 
 #: ./error.py:147
-#: ./reserve.py:471
+#: ./reserve.py:472
 msgid "Reservation out of bounds"
 msgstr "Réservation hors du périmètre défini"
 
-#: ./interfaces.py:336
+#: ./interfaces.py:338
 msgid "Reservation quota limit must zero or a positive number"
 msgstr "Le nombre de réservations doit être au moins de 0 ou plus"
 
-#: ./reserve.py:852
+#: ./reserve.py:853
 msgid "Reservation removed"
 msgstr "Réservation supprimée"
 
-#: ./reserve.py:925
+#: ./reserve.py:924
 msgid "Reservation revoked"
 msgstr "Réservation annulée"
 
@@ -694,7 +700,7 @@ msgstr ""
 msgid "Reservations (Normal)"
 msgstr ""
 
-#: ./reserve.py:647
+#: ./reserve.py:648
 msgid "Reservations Successfully Submitted"
 msgstr "Réservation a été effectuée avec succès"
 
@@ -706,12 +712,12 @@ msgstr "Les réservations ne peuvent pas être faites au-delà de 24 heures"
 msgid "Reservations in the last 30 days"
 msgstr ""
 
-#: ./reserve.py:514
+#: ./reserve.py:515
 #: ./resource.py:342
 msgid "Reserve"
 msgstr "Réserver"
 
-#: ./reserve.py:651
+#: ./reserve.py:652
 msgid "Reserve More"
 msgstr "Autres options de réservations"
 
@@ -728,12 +734,12 @@ msgstr "Réservation"
 msgid "Resources"
 msgstr "Ressources"
 
-#: ./reserve.py:917
-#: ./templates/macros.pt:123
+#: ./reserve.py:916
+#: ./templates/macros.pt:125
 msgid "Revoke"
 msgstr "Annuler"
 
-#: ./reserve.py:904
+#: ./reserve.py:903
 msgid "Revoke reservation"
 msgstr "Annuler la réservation"
 
@@ -741,12 +747,12 @@ msgstr "Annuler la réservation"
 msgid "Run custom validation code for reservations. This is for advanced users only and may disable the reservations process. For documentation study the source code at Github."
 msgstr ""
 
-#: ./interfaces.py:53
+#: ./interfaces.py:55
 msgid "Sa"
 msgstr "Sa"
 
-#: ./mail.py:447
-#: ./reserve.py:1081
+#: ./mail.py:482
+#: ./reserve.py:1178
 #: ./timeframe.py:83
 msgid "Save"
 msgstr "Enregistrer"
@@ -759,27 +765,27 @@ msgstr "Seantis Centre de contrôle des réservations"
 msgid "Seantis Reservation Settings"
 msgstr "Seantis Réglage des réservations"
 
-#: ./interfaces.py:87
+#: ./interfaces.py:89
 msgid "Select at least one value"
 msgstr "Choisir au moins un valeur"
 
-#: ./interfaces.py:408
+#: ./interfaces.py:410
 msgid "Selected Date"
 msgstr "Date choisie"
 
-#: ./interfaces.py:398
+#: ./interfaces.py:400
 msgid "Selected View"
 msgstr "Vue choisie"
 
-#: ./interfaces.py:399
+#: ./interfaces.py:401
 msgid "Selected view when opening the calendar."
 msgstr "Affichage lors de l'ouverture du calendrier"
 
-#: ./interfaces.py:813
+#: ./interfaces.py:829
 msgid "Send Email"
 msgstr ""
 
-#: ./interfaces.py:814
+#: ./interfaces.py:830
 msgid "Send an email to the reservee informing him of the revocation"
 msgstr ""
 
@@ -795,35 +801,35 @@ msgstr "Envoyer un courriel auprès des managers concernant les réservations en
 msgid "Send emails about newly made reservations to the first reservation managers found in the path."
 msgstr "Envoyer un courriel pour une nouvelle réservation au premier manager des réservation au système."
 
-#: ./interfaces.py:648
+#: ./interfaces.py:664
 msgid "Sent to <b>managers</b> when a new pending reservation is made. May contain the template variables listed below."
 msgstr "Envoyer à <b>managers</b> quand une nouvelle réservation est faite. Peut contenir les données variables listées ci-dessous."
 
-#: ./interfaces.py:634
+#: ./interfaces.py:650
 msgid "Sent to <b>managers</b> when a reservation is automatically approved. May contain the template variables listed below."
 msgstr "Envoyer à  <b>managers</b> quand une réservation est approuvée. Peut contenir les données variables listées ci-dessous."
 
-#: ./interfaces.py:663
+#: ./interfaces.py:679
 msgid "Sent to <b>users</b> when a new pending reservation is made. May contain the template variables listed below."
 msgstr "Envoyer à <b>users</b> quand une réservation est en attente. Peut contenir les données variables listées ci-dessous."
 
-#: ./interfaces.py:678
+#: ./interfaces.py:694
 msgid "Sent to <b>users</b> when a reservation is approved. May contain the template variables listed below."
 msgstr "Envoyer à <b>users</b> quand une nouvelle réservation est en attente. Peut contenir les données variables listées ci-dessous."
 
-#: ./interfaces.py:691
+#: ./interfaces.py:707
 msgid "Sent to <b>users</b> when a reservation is denied. May contain the template variables listed below."
 msgstr "Envoyer à <b>users</b> quand une réservation est refusée. Peut contenir les données variables listées ci-dessous."
 
-#: ./interfaces.py:704
+#: ./interfaces.py:720
 msgid "Sent to <b>users</b> when a reservation is revoked. May contain the template variables listed below."
 msgstr "Envoyer à <b>users</b> quand une réservation est annulée. Peut contenir les données variables listées ci-dessous."
 
-#: ./interfaces.py:554
+#: ./interfaces.py:567
 msgid "Separately reservable"
 msgstr "Réserver séparément"
 
-#: ./allocate.py:184
+#: ./allocate.py:185
 msgid "Settings"
 msgstr "Vues"
 
@@ -831,12 +837,12 @@ msgstr "Vues"
 msgid "Show"
 msgstr "Afficher"
 
-#: ./interfaces.py:418
+#: ./interfaces.py:420
 msgid "Specific Date"
 msgstr "Date définie"
 
 #: ./exports/reservations.py:46
-#: ./interfaces.py:510
+#: ./interfaces.py:523
 msgid "Start"
 msgstr "Début"
 
@@ -848,19 +854,19 @@ msgstr "Statut"
 msgid "Statuses"
 msgstr "Statuts"
 
-#: ./interfaces.py:54
+#: ./interfaces.py:56
 msgid "Su"
 msgstr "Di"
 
-#: ./interfaces.py:434
+#: ./interfaces.py:436
 msgid "Subforms that need to be filled out to make a reservation. Forms can currently only be created by a site-administrator."
 msgstr "Les formulaires doivent être remplis pour faire votre demande de réservations. Les formulaires disponibles sont à ce jour seulement disponibles via le gestionnaire du site."
 
-#: ./reserve.py:643
+#: ./reserve.py:644
 msgid "Submit Reservations"
 msgstr "Confirmation et fermeture"
 
-#: ./interfaces.py:51
+#: ./interfaces.py:53
 msgid "Th"
 msgstr "Je"
 
@@ -868,11 +874,11 @@ msgstr "Je"
 msgid "The allocation does not have enough spots to possibly satisfy the requested reservation quota."
 msgstr "La salle n'a pas les capacités pour répondre à la demande de réservation."
 
-#: ./interfaces.py:571
+#: ./interfaces.py:587
 msgid "The allocation must be at least 5 minutes long"
 msgstr "La salle doit être au moins réservée pour 5 minutes."
 
-#: ./interfaces.py:531
+#: ./interfaces.py:544
 msgid "The allocation spans the whole day."
 msgstr "La périodisation est valable pour toute la journée."
 
@@ -892,7 +898,7 @@ msgstr "Le token de réservation n'est pas valable."
 msgid "The item does no longer exist."
 msgstr "La saisie effectuée n'existe plus."
 
-#: ./interfaces.py:285
+#: ./interfaces.py:287
 msgid "The maximum quota a single reservation may occupy at once. There is no limit if set to zero."
 msgstr "Le quota maximum d'une seule réservation peut être utilisé de suite."
 
@@ -928,7 +934,7 @@ msgstr "La salle demandée est actuellement utilisée. Veuillez à nouveau essay
 msgid "The resulting allocation would be invalid"
 msgstr "Les données saisies ne sont pas valables."
 
-#: ./interfaces.py:474
+#: ./interfaces.py:476
 msgid "The selected view must be one of the available views."
 msgstr "Le choix de l'affichage doit être disponible."
 
@@ -940,7 +946,7 @@ msgstr "${nb} Des réservations sont saisies momentanément."
 msgid "There is one reservation being entered for this resource."
 msgstr "Une réservation est saisie momentanément."
 
-#: ./mail.py:432
+#: ./mail.py:467
 msgid "There's already an Email template in the same folder for the same language"
 msgstr "Il existe déjà un autre courriel dans le dossier avec les mêmes données."
 
@@ -956,7 +962,7 @@ msgstr "Période d'occupation"
 msgid "Timeframe overlaps with '${overlap}' in the current folder"
 msgstr "La période d'occupation est en conflit avec '${overlap}'"
 
-#: ./interfaces.py:504
+#: ./interfaces.py:517
 #: ./templates/timeframes.pt:4
 msgid "Timeframes"
 msgstr "Périodes d'occupation"
@@ -977,7 +983,7 @@ msgstr "Token"
 msgid "Too many reservations in a short time. Wait for a moment before trying again."
 msgstr "Trop de réservations en parallèle. Recommencer dans quelques minutes."
 
-#: ./interfaces.py:49
+#: ./interfaces.py:51
 msgid "Tu"
 msgstr "Ma"
 
@@ -989,11 +995,11 @@ msgstr "Pas disponible"
 msgid "Utils"
 msgstr "Outil"
 
-#: ./interfaces.py:386
+#: ./interfaces.py:388
 msgid "Views available to the user on the calendar."
 msgstr "Mode d'affichage disponibles pour l'utilisateur"
 
-#: ./interfaces.py:761
+#: ./interfaces.py:777
 msgid "Visible on the calendar"
 msgstr ""
 
@@ -1001,20 +1007,20 @@ msgstr ""
 msgid "Waitinglist"
 msgstr "Liste d'attente"
 
-#: ./utils.py:744
+#: ./utils.py:745
 msgid "Waitinglist is Free"
 msgstr "Pas de liste d'attente"
 
-#: ./interfaces.py:50
+#: ./interfaces.py:52
 msgid "We"
 msgstr "Me"
 
-#: ./interfaces.py:68
+#: ./interfaces.py:70
 msgid "Weekly View"
 msgstr "Vue hebdomadaire"
 
 #: ./exports/reservations.py:48
-#: ./interfaces.py:530
+#: ./interfaces.py:543
 #: ./resource.py:437
 msgid "Whole Day"
 msgstr "Toute la journée"
@@ -1027,7 +1033,7 @@ msgstr "Oui"
 msgid "Yesterday, at ${time}"
 msgstr ""
 
-#: ./interfaces.py:466
+#: ./interfaces.py:468
 msgid "You chose to 'Always show a specific date' but you did not specify a specific date"
 msgstr "Vous avez choisi l'option de 'Toujours montrer une date précise' mais vous n'avez pas précisé de date"
 
@@ -1036,4 +1042,8 @@ msgstr "Vous avez choisi l'option de 'Toujours montrer une date précise' mais v
 msgid "Your reservations"
 msgstr "Vos réservations"
 
+#. Default: "Please specify a valid time, for example 09:00"
+#: ./converter.py:47
+msgid "msg_error_time_value"
+msgstr "Spécifier l'heure correcte, par exemple 09:00"
 

--- a/seantis/reservation/locales/seantis.reservation.pot
+++ b/seantis/reservation/locales/seantis.reservation.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-10-28 16:18+0000\n"
+"POT-Creation-Date: 2013-11-12 12:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,23 +25,23 @@ msgstr ""
 msgid "${days} days ago, at ${time}"
 msgstr ""
 
-#: ./interfaces.py:614
+#: ./interfaces.py:630
 msgid "%(reason)s - reason for revocation<br>"
 msgstr ""
 
-#: ./utils.py:748
+#: ./utils.py:749
 msgid "%i People Waiting"
 msgstr ""
 
-#: ./utils.py:729
+#: ./utils.py:730
 msgid "%i%% Free"
 msgstr ""
 
-#: ./utils.py:736
+#: ./utils.py:737
 msgid "%i/%i Spot Available"
 msgstr ""
 
-#: ./utils.py:732
+#: ./utils.py:733
 msgid "%i/%i Spots Available"
 msgstr ""
 
@@ -49,15 +49,15 @@ msgstr ""
 msgid "&lt;&lt; Previous Month"
 msgstr ""
 
-#: ./templates/macros.pt:175
+#: ./templates/macros.pt:177
 msgid "&raquo; Edit Formdata"
 msgstr ""
 
-#: ./utils.py:587
+#: ./utils.py:588
 msgid "<b>${quota}</b> reservations"
 msgstr ""
 
-#: ./utils.py:589
+#: ./utils.py:590
 msgid "<b>1</b> reservation"
 msgstr ""
 
@@ -69,7 +69,7 @@ msgstr ""
 msgid "A pending reservation would be affected by the requested change"
 msgstr ""
 
-#: ./mail.py:495
+#: ./mail.py:530
 msgid "Add email template"
 msgstr ""
 
@@ -93,35 +93,35 @@ msgstr ""
 msgid "Allocation"
 msgstr ""
 
-#: ./interfaces.py:785
+#: ./interfaces.py:801
 msgid "Allocation Id"
 msgstr ""
 
-#: ./allocate.py:132
+#: ./allocate.py:133
 msgid "Allocation added"
 msgstr ""
 
-#: ./allocate.py:294
+#: ./allocate.py:295
 msgid "Allocation removed"
 msgstr ""
 
-#: ./allocate.py:251
+#: ./allocate.py:252
 msgid "Allocation saved"
 msgstr ""
 
-#: ./interfaces.py:520
+#: ./interfaces.py:533
 msgid "Allocations may end every 5 minutes if the allocation is not partly available. If it is partly available the start time may be every x minute where x equals the given raster. The minimum length of an allocation is also either 5 minutes or whatever the value of the raster is."
 msgstr ""
 
-#: ./interfaces.py:511
+#: ./interfaces.py:524
 msgid "Allocations may start every 5 minutes if the allocation is not partly available. If it is partly available the start time may be every x minute where x equals the given raster."
 msgstr ""
 
-#: ./interfaces.py:79
+#: ./interfaces.py:81
 msgid "Always show a specific date"
 msgstr ""
 
-#: ./interfaces.py:78
+#: ./interfaces.py:80
 msgid "Always show the current date"
 msgstr ""
 
@@ -134,12 +134,12 @@ msgid "Approval Email Notifications for Managers"
 msgstr ""
 
 #: ./reports/monthly_report.py:226
-#: ./reserve.py:734
-#: ./templates/macros.pt:134
+#: ./reserve.py:735
+#: ./templates/macros.pt:136
 msgid "Approve"
 msgstr ""
 
-#: ./reserve.py:725
+#: ./reserve.py:726
 msgid "Approve reservation"
 msgstr ""
 
@@ -148,7 +148,7 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: ./interfaces.py:385
+#: ./interfaces.py:387
 msgid "Available Views"
 msgstr ""
 
@@ -156,7 +156,7 @@ msgstr ""
 msgid "CSV Format"
 msgstr ""
 
-#: ./interfaces.py:409
+#: ./interfaces.py:411
 msgid "Calendar date shown when opening the calendar."
 msgstr ""
 
@@ -164,8 +164,8 @@ msgstr ""
 msgid "Can't block period because a reservation already exists."
 msgstr ""
 
-#: ./allocate.py:151
-#: ./reserve.py:538
+#: ./allocate.py:152
+#: ./reserve.py:539
 msgid "Cancel"
 msgstr ""
 
@@ -181,7 +181,7 @@ msgstr ""
 msgid "Compare Resources"
 msgstr ""
 
-#: ./templates/macros.pt:191
+#: ./templates/macros.pt:193
 msgid "Concerned Dates"
 msgstr ""
 
@@ -193,15 +193,15 @@ msgstr ""
 msgid "Created"
 msgstr ""
 
-#: ./interfaces.py:341
+#: ./interfaces.py:343
 msgid "DEPRECATED: Approve reservation requests"
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:63
 msgid "Daily"
 msgstr ""
 
-#: ./interfaces.py:69
+#: ./interfaces.py:71
 msgid "Daily View"
 msgstr ""
 
@@ -209,39 +209,39 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: ./interfaces.py:544
+#: ./interfaces.py:557
 msgid "Day"
 msgstr ""
 
-#: ./interfaces.py:548
+#: ./interfaces.py:561
 msgid "Days"
 msgstr ""
 
-#: ./interfaces.py:424
+#: ./interfaces.py:426
 msgid "Default Allocation Values"
 msgstr ""
 
-#: ./interfaces.py:317
+#: ./interfaces.py:319
 msgid "Defines the minimum length of any given reservation as well as the alignment of the start / end of the allocation. E.g. a raster of 30 minutes means that the allocation can only start at xx:00 and xx:30 respectively"
 msgstr ""
 
-#: ./allocate.py:278
-#: ./mail.py:504
+#: ./allocate.py:279
+#: ./mail.py:539
 #: ./reports/monthly_report.py:220
 msgid "Delete"
 msgstr ""
 
 #: ./reports/monthly_report.py:232
-#: ./reserve.py:767
-#: ./templates/macros.pt:130
+#: ./reserve.py:768
+#: ./templates/macros.pt:132
 msgid "Deny"
 msgstr ""
 
-#: ./reserve.py:758
+#: ./reserve.py:759
 msgid "Deny reservation"
 msgstr ""
 
-#: ./interfaces.py:355
+#: ./interfaces.py:357
 msgid "Description"
 msgstr ""
 
@@ -249,11 +249,11 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: ./reserve.py:732
+#: ./reserve.py:733
 msgid "Do you really want to approve the following reservations?"
 msgstr ""
 
-#: ./reserve.py:765
+#: ./reserve.py:766
 msgid "Do you really want to deny the following reservations?"
 msgstr ""
 
@@ -261,11 +261,11 @@ msgstr ""
 msgid "Do you really want to remove the following allocations?"
 msgstr ""
 
-#: ./reserve.py:841
+#: ./reserve.py:842
 msgid "Do you really want to remove the following reservations?"
 msgstr ""
 
-#: ./reserve.py:913
+#: ./reserve.py:912
 msgid "Do you really want to revoke the following reservations?"
 msgstr ""
 
@@ -273,22 +273,22 @@ msgstr ""
 msgid "Do you want to reserve the following allocations?"
 msgstr ""
 
-#: ./allocate.py:223
-#: ./mail.py:503
+#: ./allocate.py:224
+#: ./mail.py:538
 #: ./resource.py:369
 msgid "Edit"
 msgstr ""
 
-#: ./reserve.py:1025
-msgid "Edit Formdata"
-msgstr ""
-
-#: ./allocate.py:173
+#: ./allocate.py:174
 msgid "Edit allocation"
 msgstr ""
 
+#: ./reserve.py:1029
+msgid "Edit reservation"
+msgstr ""
+
 #: ./exports/reservations.py:45
-#: ./interfaces.py:145
+#: ./interfaces.py:147
 msgid "Email"
 msgstr ""
 
@@ -300,31 +300,31 @@ msgstr ""
 msgid "Email Notifications for Reservees"
 msgstr ""
 
-#: ./interfaces.py:677
+#: ./interfaces.py:693
 msgid "Email Subject for Approved Reservations"
 msgstr ""
 
-#: ./interfaces.py:690
+#: ./interfaces.py:706
 msgid "Email Subject for Denied Reservations"
 msgstr ""
 
-#: ./interfaces.py:662
+#: ./interfaces.py:678
 msgid "Email Subject for Received Reservations"
 msgstr ""
 
-#: ./interfaces.py:633
+#: ./interfaces.py:649
 msgid "Email Subject for Reservation Autoapproved"
 msgstr ""
 
-#: ./interfaces.py:647
+#: ./interfaces.py:663
 msgid "Email Subject for Reservation Pending"
 msgstr ""
 
-#: ./interfaces.py:703
+#: ./interfaces.py:719
 msgid "Email Subject for Revoked Reservations"
 msgstr ""
 
-#: ./mail.py:96
+#: ./mail.py:115
 #: ./profiles/default/types/seantis.reservation.emailtemplate.xml
 msgid "Email Template"
 msgstr ""
@@ -333,36 +333,36 @@ msgstr ""
 msgid "Email Templates"
 msgstr ""
 
-#: ./interfaces.py:684
+#: ./interfaces.py:700
 msgid "Email Text for Approved Reservations"
 msgstr ""
 
-#: ./interfaces.py:697
+#: ./interfaces.py:713
 msgid "Email Text for Denied Reservations"
 msgstr ""
 
-#: ./interfaces.py:671
+#: ./interfaces.py:687
 msgid "Email Text for Received Reservations"
 msgstr ""
 
-#: ./interfaces.py:641
+#: ./interfaces.py:657
 msgid "Email Text for Reservation Autoapproved"
 msgstr ""
 
-#: ./interfaces.py:656
+#: ./interfaces.py:672
 msgid "Email Text for Reservation Pending"
 msgstr ""
 
-#: ./interfaces.py:710
+#: ./interfaces.py:726
 msgid "Email Text for Revoked Reservations"
 msgstr ""
 
 #: ./exports/reservations.py:47
-#: ./interfaces.py:519
+#: ./interfaces.py:532
 msgid "End"
 msgstr ""
 
-#: ./interfaces.py:601
+#: ./interfaces.py:617
 msgid "End date before start date"
 msgstr ""
 
@@ -370,11 +370,11 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: ./interfaces.py:374
+#: ./interfaces.py:376
 msgid "Everything after this hour is not shown in the calendar, making the calendar display more compact. Should be set to an hour after which there cannot be any reservations."
 msgstr ""
 
-#: ./interfaces.py:362
+#: ./interfaces.py:364
 msgid "Everything before this hour is not shown in the calendar, making the calendar display more compact. Should be set to an hour before which there cannot be any reservations."
 msgstr ""
 
@@ -387,23 +387,23 @@ msgstr ""
 msgid "Export Reservations"
 msgstr ""
 
-#: ./interfaces.py:459
+#: ./interfaces.py:461
 msgid "First hour must be smaller than last hour"
 msgstr ""
 
-#: ./interfaces.py:361
+#: ./interfaces.py:363
 msgid "First hour of the day"
 msgstr ""
 
-#: ./reserve.py:1090
+#: ./reserve.py:1199
 msgid "Formdata updated"
 msgstr ""
 
-#: ./interfaces.py:433
+#: ./interfaces.py:435
 msgid "Formsets"
 msgstr ""
 
-#: ./interfaces.py:52
+#: ./interfaces.py:54
 msgid "Fr"
 msgstr ""
 
@@ -423,19 +423,19 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: ./interfaces.py:492
+#: ./interfaces.py:505
 msgid "Id"
 msgstr ""
 
-#: ./interfaces.py:295
+#: ./interfaces.py:297
 msgid "If checked a reservation manager must decide if a reservation can be approved. Until then users are added to a waitinglist. Reservations are automatically approved if this is not checked. "
 msgstr ""
 
-#: ./interfaces.py:555
+#: ./interfaces.py:568
 msgid "If checked parts of the recurrance may be reserved. If not checked the recurrance must be reserved as a whole."
 msgstr ""
 
-#: ./interfaces.py:306
+#: ./interfaces.py:308
 msgid "If the allocation is partly available users may reserve only a part of it (e.g. half of it). If not the allocation Must be reserved as a whole or not at all"
 msgstr ""
 
@@ -443,19 +443,19 @@ msgstr ""
 msgid "Invalid change. Your request may have already been processed earlier."
 msgstr ""
 
-#: ./interfaces.py:130
+#: ./interfaces.py:132
 msgid "Invalid email address"
 msgstr ""
 
-#: ./interfaces.py:452
+#: ./interfaces.py:454
 msgid "Invalid first hour"
 msgstr ""
 
-#: ./interfaces.py:455
+#: ./interfaces.py:457
 msgid "Invalid last hour"
 msgstr ""
 
-#: ./reserve.py:475
+#: ./reserve.py:476
 msgid "Invalid reservation request"
 msgstr ""
 
@@ -463,11 +463,11 @@ msgstr ""
 msgid "JSON Format"
 msgstr ""
 
-#: ./interfaces.py:628
+#: ./interfaces.py:644
 msgid "Language"
 msgstr ""
 
-#: ./interfaces.py:373
+#: ./interfaces.py:375
 msgid "Last hour of the day"
 msgstr ""
 
@@ -487,19 +487,19 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: ./interfaces.py:294
+#: ./interfaces.py:296
 msgid "Manually approve reservation requests"
 msgstr ""
 
-#: ./interfaces.py:618
+#: ./interfaces.py:634
 msgid "May contain the following template variable:<br>%(reservations)s - list of reservations"
 msgstr ""
 
-#: ./interfaces.py:603
+#: ./interfaces.py:619
 msgid "May contain the following template variables:<br>%(resource)s - title of the resource<br>%(dates)s - list of dates reserved<br>%(reservation_mail)s - email of reservee<br>%(data)s - formdata associated with the reservation<br>%(approval_link)s - link to the approval view<br>%(denial_link)s - link to the denial view<br>%(cancel_link)s - link to the cancel view"
 msgstr ""
 
-#: ./interfaces.py:48
+#: ./interfaces.py:50
 msgid "Mo"
 msgstr ""
 
@@ -515,11 +515,11 @@ msgstr ""
 msgid "Monthly Report for ${month} ${year}"
 msgstr ""
 
-#: ./interfaces.py:67
+#: ./interfaces.py:69
 msgid "Monthly View"
 msgstr ""
 
-#: ./interfaces.py:351
+#: ./interfaces.py:353
 msgid "Name"
 msgstr ""
 
@@ -535,10 +535,6 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: ./reserve.py:1027
-msgid "No Formdata to edit"
-msgstr ""
-
 #: ./error.py:134
 msgid "No reservable slot found."
 msgstr ""
@@ -547,23 +543,23 @@ msgstr ""
 msgid "No reserved slots would be left after this operation"
 msgstr ""
 
-#: ./reserve.py:730
+#: ./reserve.py:731
 msgid "No such reservation"
 msgstr ""
 
-#: ./interfaces.py:274
+#: ./interfaces.py:276
 msgid "Number of times an allocation may be reserved at the same time. e.g. 3 spots in a daycare center, 2 available cars, 1 meeting room. "
 msgstr ""
 
-#: ./interfaces.py:60
+#: ./interfaces.py:62
 msgid "Once"
 msgstr ""
 
-#: ./utils.py:746
+#: ./utils.py:747
 msgid "One Person Waiting"
 msgstr ""
 
-#: ./interfaces.py:822
+#: ./interfaces.py:838
 msgid "Optional reason for the revocation. Sent to the reservee. e.g. 'Your reservation has to be cancelled because the lecturer is ill'."
 msgstr ""
 
@@ -571,13 +567,13 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: ./interfaces.py:305
+#: ./interfaces.py:307
 #: ./templates/resource.pt:60
 msgid "Partly available"
 msgstr ""
 
-#: ./allocate.py:146
-#: ./interfaces.py:577
+#: ./allocate.py:147
+#: ./interfaces.py:593
 msgid "Partly available allocations can only be reserved separately"
 msgstr ""
 
@@ -590,32 +586,32 @@ msgstr ""
 msgid "Pre-Reservation Script"
 msgstr ""
 
-#: ./templates/macros.pt:140
+#: ./templates/macros.pt:142
 msgid "Print"
 msgstr ""
 
 #: ./exports/reservations.py:50
-#: ./interfaces.py:273
+#: ./interfaces.py:275
 msgid "Quota"
 msgstr ""
 
-#: ./interfaces.py:330
+#: ./interfaces.py:332
 msgid "Quota must be between 1 and 1000"
 msgstr ""
 
-#: ./interfaces.py:316
+#: ./interfaces.py:318
 msgid "Raster"
 msgstr ""
 
-#: ./interfaces.py:821
+#: ./interfaces.py:837
 msgid "Reason"
 msgstr ""
 
-#: ./reserve.py:576
+#: ./reserve.py:577
 msgid "Recurrance reservation"
 msgstr ""
 
-#: ./interfaces.py:498
+#: ./interfaces.py:511
 msgid "Recurrence"
 msgstr ""
 
@@ -627,29 +623,37 @@ msgstr ""
 msgid "Recurrences"
 msgstr ""
 
-#: ./reserve.py:845
+#: ./reserve.py:846
 #: ./resource.py:373
 #: ./templates/your_reservations_viewlet.pt:16
 msgid "Remove"
 msgstr ""
 
-#: ./allocate.py:273
+#: ./allocate.py:274
 msgid "Remove allocations"
 msgstr ""
 
-#: ./reserve.py:801
+#: ./templates/macros.pt:212
+msgid "Remove future reservations"
+msgstr ""
+
+#: ./templates/macros.pt:206
+msgid "Remove reservation"
+msgstr ""
+
+#: ./reserve.py:802
 msgid "Remove reservations"
 msgstr ""
 
-#: ./interfaces.py:776
+#: ./interfaces.py:792
 msgid "Reservation"
 msgstr ""
 
-#: ./interfaces.py:749
+#: ./interfaces.py:765
 msgid "Reservation Quota"
 msgstr ""
 
-#: ./interfaces.py:284
+#: ./interfaces.py:286
 msgid "Reservation Quota Limit"
 msgstr ""
 
@@ -657,28 +661,28 @@ msgstr ""
 msgid "Reservation Throttling"
 msgstr ""
 
-#: ./reserve.py:740
+#: ./reserve.py:741
 msgid "Reservation confirmed"
 msgstr ""
 
-#: ./reserve.py:773
+#: ./reserve.py:774
 msgid "Reservation denied"
 msgstr ""
 
 #: ./error.py:147
-#: ./reserve.py:471
+#: ./reserve.py:472
 msgid "Reservation out of bounds"
 msgstr ""
 
-#: ./interfaces.py:336
+#: ./interfaces.py:338
 msgid "Reservation quota limit must zero or a positive number"
 msgstr ""
 
-#: ./reserve.py:852
+#: ./reserve.py:853
 msgid "Reservation removed"
 msgstr ""
 
-#: ./reserve.py:925
+#: ./reserve.py:924
 msgid "Reservation revoked"
 msgstr ""
 
@@ -699,7 +703,7 @@ msgstr ""
 msgid "Reservations (Normal)"
 msgstr ""
 
-#: ./reserve.py:647
+#: ./reserve.py:648
 msgid "Reservations Successfully Submitted"
 msgstr ""
 
@@ -711,12 +715,12 @@ msgstr ""
 msgid "Reservations in the last 30 days"
 msgstr ""
 
-#: ./reserve.py:514
+#: ./reserve.py:515
 #: ./resource.py:342
 msgid "Reserve"
 msgstr ""
 
-#: ./reserve.py:651
+#: ./reserve.py:652
 msgid "Reserve More"
 msgstr ""
 
@@ -733,12 +737,12 @@ msgstr ""
 msgid "Resources"
 msgstr ""
 
-#: ./reserve.py:917
-#: ./templates/macros.pt:123
+#: ./reserve.py:916
+#: ./templates/macros.pt:125
 msgid "Revoke"
 msgstr ""
 
-#: ./reserve.py:904
+#: ./reserve.py:903
 msgid "Revoke reservation"
 msgstr ""
 
@@ -746,12 +750,12 @@ msgstr ""
 msgid "Run custom validation code for reservations. This is for advanced users only and may disable the reservations process. For documentation study the source code at Github."
 msgstr ""
 
-#: ./interfaces.py:53
+#: ./interfaces.py:55
 msgid "Sa"
 msgstr ""
 
-#: ./mail.py:447
-#: ./reserve.py:1081
+#: ./mail.py:482
+#: ./reserve.py:1178
 #: ./timeframe.py:83
 msgid "Save"
 msgstr ""
@@ -764,27 +768,27 @@ msgstr ""
 msgid "Seantis Reservation Settings"
 msgstr ""
 
-#: ./interfaces.py:87
+#: ./interfaces.py:89
 msgid "Select at least one value"
 msgstr ""
 
-#: ./interfaces.py:408
+#: ./interfaces.py:410
 msgid "Selected Date"
 msgstr ""
 
-#: ./interfaces.py:398
+#: ./interfaces.py:400
 msgid "Selected View"
 msgstr ""
 
-#: ./interfaces.py:399
+#: ./interfaces.py:401
 msgid "Selected view when opening the calendar."
 msgstr ""
 
-#: ./interfaces.py:813
+#: ./interfaces.py:829
 msgid "Send Email"
 msgstr ""
 
-#: ./interfaces.py:814
+#: ./interfaces.py:830
 msgid "Send an email to the reservee informing him of the revocation"
 msgstr ""
 
@@ -800,35 +804,35 @@ msgstr ""
 msgid "Send emails about newly made reservations to the first reservation managers found in the path."
 msgstr ""
 
-#: ./interfaces.py:648
+#: ./interfaces.py:664
 msgid "Sent to <b>managers</b> when a new pending reservation is made. May contain the template variables listed below."
 msgstr ""
 
-#: ./interfaces.py:634
+#: ./interfaces.py:650
 msgid "Sent to <b>managers</b> when a reservation is automatically approved. May contain the template variables listed below."
 msgstr ""
 
-#: ./interfaces.py:663
+#: ./interfaces.py:679
 msgid "Sent to <b>users</b> when a new pending reservation is made. May contain the template variables listed below."
 msgstr ""
 
-#: ./interfaces.py:678
+#: ./interfaces.py:694
 msgid "Sent to <b>users</b> when a reservation is approved. May contain the template variables listed below."
 msgstr ""
 
-#: ./interfaces.py:691
+#: ./interfaces.py:707
 msgid "Sent to <b>users</b> when a reservation is denied. May contain the template variables listed below."
 msgstr ""
 
-#: ./interfaces.py:704
+#: ./interfaces.py:720
 msgid "Sent to <b>users</b> when a reservation is revoked. May contain the template variables listed below."
 msgstr ""
 
-#: ./interfaces.py:554
+#: ./interfaces.py:567
 msgid "Separately reservable"
 msgstr ""
 
-#: ./allocate.py:184
+#: ./allocate.py:185
 msgid "Settings"
 msgstr ""
 
@@ -836,12 +840,12 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
-#: ./interfaces.py:418
+#: ./interfaces.py:420
 msgid "Specific Date"
 msgstr ""
 
 #: ./exports/reservations.py:46
-#: ./interfaces.py:510
+#: ./interfaces.py:523
 msgid "Start"
 msgstr ""
 
@@ -853,19 +857,19 @@ msgstr ""
 msgid "Statuses"
 msgstr ""
 
-#: ./interfaces.py:54
+#: ./interfaces.py:56
 msgid "Su"
 msgstr ""
 
-#: ./interfaces.py:434
+#: ./interfaces.py:436
 msgid "Subforms that need to be filled out to make a reservation. Forms can currently only be created by a site-administrator."
 msgstr ""
 
-#: ./reserve.py:643
+#: ./reserve.py:644
 msgid "Submit Reservations"
 msgstr ""
 
-#: ./interfaces.py:51
+#: ./interfaces.py:53
 msgid "Th"
 msgstr ""
 
@@ -873,11 +877,11 @@ msgstr ""
 msgid "The allocation does not have enough spots to possibly satisfy the requested reservation quota."
 msgstr ""
 
-#: ./interfaces.py:571
+#: ./interfaces.py:587
 msgid "The allocation must be at least 5 minutes long"
 msgstr ""
 
-#: ./interfaces.py:531
+#: ./interfaces.py:544
 msgid "The allocation spans the whole day."
 msgstr ""
 
@@ -897,7 +901,7 @@ msgstr ""
 msgid "The item does no longer exist."
 msgstr ""
 
-#: ./interfaces.py:285
+#: ./interfaces.py:287
 msgid "The maximum quota a single reservation may occupy at once. There is no limit if set to zero."
 msgstr ""
 
@@ -933,7 +937,7 @@ msgstr ""
 msgid "The resulting allocation would be invalid"
 msgstr ""
 
-#: ./interfaces.py:474
+#: ./interfaces.py:476
 msgid "The selected view must be one of the available views."
 msgstr ""
 
@@ -945,7 +949,7 @@ msgstr ""
 msgid "There is one reservation being entered for this resource."
 msgstr ""
 
-#: ./mail.py:432
+#: ./mail.py:467
 msgid "There's already an Email template in the same folder for the same language"
 msgstr ""
 
@@ -961,7 +965,7 @@ msgstr ""
 msgid "Timeframe overlaps with '${overlap}' in the current folder"
 msgstr ""
 
-#: ./interfaces.py:504
+#: ./interfaces.py:517
 #: ./templates/timeframes.pt:4
 msgid "Timeframes"
 msgstr ""
@@ -982,7 +986,7 @@ msgstr ""
 msgid "Too many reservations in a short time. Wait for a moment before trying again."
 msgstr ""
 
-#: ./interfaces.py:49
+#: ./interfaces.py:51
 msgid "Tu"
 msgstr ""
 
@@ -994,11 +998,11 @@ msgstr ""
 msgid "Utils"
 msgstr ""
 
-#: ./interfaces.py:386
+#: ./interfaces.py:388
 msgid "Views available to the user on the calendar."
 msgstr ""
 
-#: ./interfaces.py:761
+#: ./interfaces.py:777
 msgid "Visible on the calendar"
 msgstr ""
 
@@ -1006,20 +1010,20 @@ msgstr ""
 msgid "Waitinglist"
 msgstr ""
 
-#: ./utils.py:744
+#: ./utils.py:745
 msgid "Waitinglist is Free"
 msgstr ""
 
-#: ./interfaces.py:50
+#: ./interfaces.py:52
 msgid "We"
 msgstr ""
 
-#: ./interfaces.py:68
+#: ./interfaces.py:70
 msgid "Weekly View"
 msgstr ""
 
 #: ./exports/reservations.py:48
-#: ./interfaces.py:530
+#: ./interfaces.py:543
 #: ./resource.py:437
 msgid "Whole Day"
 msgstr ""
@@ -1032,12 +1036,17 @@ msgstr ""
 msgid "Yesterday, at ${time}"
 msgstr ""
 
-#: ./interfaces.py:466
+#: ./interfaces.py:468
 msgid "You chose to 'Always show a specific date' but you did not specify a specific date"
 msgstr ""
 
 #: ./templates/your_reservations.pt:14
 #: ./templates/your_reservations_viewlet.pt:10
 msgid "Your reservations"
+msgstr ""
+
+#. Default: "Please specify a valid time, for example 09:00"
+#: ./converter.py:47
+msgid "msg_error_time_value"
 msgstr ""
 

--- a/seantis/reservation/models/reservation.py
+++ b/seantis/reservation/models/reservation.py
@@ -120,6 +120,10 @@ class Reservation(TimestampMixin, ORMBase, OtherModels):
         return reservation
 
     @property
+    def is_pending(self):
+        return self.status == 'pending'
+
+    @property
     def is_recurrence(self):
         return self.target_type == 'recurrence'
 

--- a/seantis/reservation/templates/macros.pt
+++ b/seantis/reservation/templates/macros.pt
@@ -67,6 +67,8 @@
       <tal:block define="
         first_reservation python: reservations[0];
         last_reservation python: reservations[-1];
+        timespan_start view/timespan_start | nothing;
+        timespan_end view/timespan_end | nothing;
       ">
         <div class="reservation">
           <tal:block define="
@@ -79,7 +81,7 @@
           <div tal:repeat="reservation reservations" class="reservation-list">
             <tal:block define="
                 data python: reservation.data;
-                timespans python: reservation.timespans();
+                timespans python: reservation.timespan_entries(start=timespan_start, end=timespan_end);
               ">
                 <metal:use use-macro="context/@@seantis-reservation-macros/reservation-data" />
                 <metal:use use-macro="context/@@seantis-reservation-macros/reservation-timespans" />
@@ -183,7 +185,7 @@
     <tal:comment replace="nothing">
     Reservation timespans block. Needs the following variables:
 
-    timespans -> list of start/end tuples
+    timespans -> list of Timespan namedtuples
     </tal:comment>
 
     <metal:define define-macro="reservation-timespans" tal:define="macro python: context.unrestrictedTraverse('@@seantis-reservation-macros')">
@@ -193,11 +195,28 @@
 
           <tal:block tal:repeat="timespan python: sorted(timespans)">
               <tal:block tal:define="
-                start python: timespan[0];
-                end python: timespan[1];
+                start python: timespan.start;
+                end python: timespan.end;
+                allocation_id python: timespan.allocation_id;
                 display python: macro.utils.display_date(start, end);
               ">
-                <div tal:content="display"></div>
+                  <div>
+                      <tal:inline tal:content="display"></tal:inline>
+                      <tal:removal_links tal:condition="show_actions | nothing">
+                      <a tal:condition="python: reservation.is_recurrence and len(timespans) > 1"
+                         class="link-overlay remove-reserved-slots"
+                         tal:attributes="href python: macro.remove_reserved_slots_url(token, allocation_id)"
+                         i18n:translate="">
+                         Remove reservation
+                      </a>
+                      <a tal:condition="not: repeat/timespan/start"
+                         class="link-overlay remove-all-reserved-slots"
+                         tal:attributes="href python: macro.remove_all_reserved_slots_url(token, allocation_id)"
+                         i18n:translate="">
+                         Remove future reservations
+                      </a>
+                      </tal:removal_links>
+                  </div>
               </tal:block>
           </tal:block>
 

--- a/seantis/reservation/templates/macros.pt
+++ b/seantis/reservation/templates/macros.pt
@@ -186,6 +186,7 @@
     Reservation timespans block. Needs the following variables:
 
     timespans -> list of Timespan namedtuples
+    reservation -> the reservation
     </tal:comment>
 
     <metal:define define-macro="reservation-timespans" tal:define="macro python: context.unrestrictedTraverse('@@seantis-reservation-macros')">
@@ -199,10 +200,11 @@
                 end python: timespan.end;
                 allocation_id python: timespan.allocation_id;
                 display python: macro.utils.display_date(start, end);
+                show_actions show_actions | nothing;
               ">
                   <div>
                       <tal:inline tal:content="display"></tal:inline>
-                      <tal:removal_links tal:condition="show_actions | nothing">
+                      <tal:removal_links tal:condition="python: show_actions and not reservation.is_pending">
                       <a tal:condition="python: reservation.is_recurrence and len(timespans) > 1"
                          class="link-overlay remove-reserved-slots"
                          tal:attributes="href python: macro.remove_reserved_slots_url(token, allocation_id)"

--- a/seantis/reservation/tests/__init__.py
+++ b/seantis/reservation/tests/__init__.py
@@ -81,8 +81,8 @@ class TestCase(unittest.TestCase):
         outlaw.execute('DELETE FROM blocked_periods')
         outlaw.execute('DELETE FROM reservations')
         outlaw.execute('DELETE FROM reserved_slots')
-        outlaw.execute('DELETE FROM recurrences')
         outlaw.execute('DELETE FROM allocations')
+        outlaw.execute('DELETE FROM recurrences')
         outlaw.dispose()
 
         self.logout()

--- a/seantis/reservation/tests/test_browser.py
+++ b/seantis/reservation/tests/test_browser.py
@@ -1,3 +1,6 @@
+from datetime import date
+from datetime import time
+from datetime import timedelta
 import json
 import transaction
 from itertools import chain
@@ -10,6 +13,7 @@ from datetime import datetime
 from seantis.reservation import utils
 from seantis.reservation import db
 from seantis.reservation.tests import FunctionalTestCase
+from seantis.reservation.db import Scheduler
 
 
 class FormsetField(object):
@@ -595,6 +599,54 @@ class TestBrowser(FunctionalTestCase):
         self.assertNotIn(
             'Please specify a valid time, for example 09:00', errors
         )
+
+    def test_remove_reserved_slots(self):
+        # setup resource and allocations
+        browser = self.new_browser()
+        browser.login_admin()
+
+        self.add_resource('removeslots')
+        resource = self.portal['testfolder']['removeslots']
+
+        db = Scheduler(resource.uuid())
+        start1 = datetime.combine(date.today(), time(resource.first_hour))
+        end1 = datetime.combine(date.today(), time(resource.last_hour))
+        start2 = start1 + timedelta(days=1)
+        end2 = end1 + timedelta(days=1)
+
+        rrule = 'RRULE:FREQ=DAILY;COUNT=2'
+        dates = (start1, end1, start2, end2)
+
+        db.allocate(
+            dates, raster=15, partly_available=True, rrule=rrule,
+            approve_manually=False, grouped=False
+        )
+        token = db.reserve(
+            u'foo@example.com', dates=dates, rrule=rrule
+        )
+        db.approve_reservation(token)
+        transaction.commit()
+
+        browser.open(self.infolder('/removeslots'))
+        menu = self.allocation_menu('removeslots', start1, end1)
+        browser.open(menu['manage'])
+
+        self.assertTrue(db.has_reserved_slot_in_range(start1, end1))
+        self.assertTrue(db.has_reserved_slot_in_range(start2, end2))
+
+        # do stuff, go to reservation overwie and make sure links are present
+        self.assertIn(
+            'Remove reservation',
+            str(browser.query('.remove-reserved-slots'))
+        )
+        # click first link
+        link = browser.getLink('Remove reservation')
+        link.click()
+        # confirm removal
+        browser.getControl('Remove').click()
+
+        self.assertFalse(db.has_reserved_slot_in_range(start1, end1))
+        self.assertTrue(db.has_reserved_slot_in_range(start2, end2))
 
     def test_reservation_approval(self):
 

--- a/seantis/reservation/tests/test_reservation.py
+++ b/seantis/reservation/tests/test_reservation.py
@@ -25,3 +25,10 @@ class TestReservation(unittest.TestCase):
         self.assertSequenceEqual([(self.reservation.start,
                                    self.reservation.end)],
                                  self.reservation.target_dates())
+
+    def test_is_pending(self):
+        self.reservation.status = 'pending'
+        self.assertTrue(self.reservation.is_pending)
+
+        self.reservation.status = 'approved'
+        self.assertFalse(self.reservation.is_pending)


### PR DESCRIPTION
This PR adds links to remove single reservations or all reservations starting at a specified date from a recurring reservation.

We somehow removed these links when merging, the corresponding `Scheduler` functionality and tests are already available.
