### PR TITLE
Make sure that the exposure checking method doesn't trip up if the resource may not be viewed and is therefore None.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,13 +5,15 @@ Changelog
 1.0.19 (unreleased)
 -------------------
 
-Nothing yet.
+- Make sure that the exposure checking method doesn't trip up if the resource
+  may not be viewed and is therefore None. Fixes #114.
+  [href]
 
 1.0.18 (2014-01-21)
 -------------------
 
 - No longer throws an exception if the allocation cannot be found. Returns
-  a 404 instead. Fixes #112
+  a 404 instead. Fixes #112.
   [href]
 
 1.0.17

--- a/seantis/reservation/exposure.py
+++ b/seantis/reservation/exposure.py
@@ -35,6 +35,8 @@ def for_allocations(context, resources):
         if checkPermission(
                 'seantis.reservation.ViewHiddenAllocations', resource):
             timeframes[uuid] = []
+        elif resource is None:
+            timeframes[uuid] = [None]
         else:
             timeframes[uuid] = timeframes_by_context(resource)
 
@@ -45,8 +47,11 @@ def for_allocations(context, resources):
         # as plone objects
         frames = timeframes[allocation.mirror_of]
 
-        if not frames:
+        if frames is None or len(frames) == 0:
             return True
+
+        if frames == [None]:
+            return False
 
         # the start date is relevant
         day = allocation.start.date()


### PR DESCRIPTION
Fixes #114.
