### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -420,6 +420,6 @@ people in the waitinglist is shown on the allcation itself.
    :target: http://travis-ci.org/seantis/seantis.reservation
 .. |Test Coverage| image:: https://coveralls.io/repos/seantis/seantis.reservation/badge.png?branch=master
    :target: https://coveralls.io/r/seantis/seantis.reservation?branch=master
-.. |PyPI Release| image:: https://pypip.in/v/seantis.reservation/badge.png
+.. |PyPI Release| image:: https://img.shields.io/pypi/v/seantis.reservation.svg
     :target: https://crate.io/packages/seantis.reservation
     :alt: Latest PyPI version


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20seantis-reservation))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `seantis-reservation`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.